### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-/collections/_api/*				@canvas-medical/technical-documentation
+/collections/_api/*				@canvas-medical/technical-documentation @canvas-medical/interoperability
 /collections/_guides/*			@canvas-medical/technical-documentation
 /collections/_sdk/*				@canvas-medical/technical-documentation


### PR DESCRIPTION
Adding Interop as codeowners. Looking at the settings for that team: https://github.com/orgs/canvas-medical/teams/interoperability/edit/review_assignment AD is not a reviewer