### PR TITLE
order api menu items by title

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -9,8 +9,9 @@
           {% if item.url %}<a href="{{ item.url }}">{{ item.title }}</a>{% else %}<strong>{{ item.title }}</strong>{% endif %}
         </div>
         {% if item.children %}
+        {% assign sortedItemChildren = item.children | sort: 'title' %}
         <ul class="toc__submenu toc__accordion toc__accordion__expanded">
-          {% for item in item.children %}
+          {% for item in sortedItemChildren %}
           <li class="toc__item">
             <div>
               {% if item.children %}<span class="toc__toggle{% if item.children %}{% for item in item.children %}{% assign this_url = item.url | split: '#' %}{% if this_url[0] == page.url %} toc__toggle__expanded{% endif %}{% endfor %}{% endif %}">{% include icons/chevron.svg %}</span>{% endif %}


### PR DESCRIPTION
Was playing around and found a possible fix for the side menu.  On `main`, `Task` is at the top and `Allergen` is missing.  This PR sorts them by title before looping through for the side menu.  

This looks like it works fine locally and seems to be the most common solution I've found online, but not my usual area so a check mark from someone before merging is probably the way to go there.