### PR TITLE
change modulo to ensure more randomness

### DIFF
--- a/_includes/blocks/block-apidoc.html
+++ b/_includes/blocks/block-apidoc.html
@@ -70,6 +70,9 @@
         </div>
     </div>
     {% if block.endpoints %}
+    {% assign min = 10001 %}
+    {% assign max = 99999 %}
+    {% assign diff = max | minus: min %}
     {% for endpoint in block.endpoints %}
     {% include blocks/block-apidoc-endpoints.html %}
     <div class="apidoc__gridrow">
@@ -103,7 +106,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.read.example_request %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="request-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -132,7 +135,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.read.example_response %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="response-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -170,7 +173,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.search.example_request %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="request-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -199,7 +202,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.search.example_response %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="response-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -226,7 +229,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.create.example_request %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="request-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -255,7 +258,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.create.example_response %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="response-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -282,7 +285,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.update.example_request %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="request-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {
@@ -311,7 +314,7 @@
         </div>
         <div class="apidoc__gridcol">
             {% if block.update.example_response %}
-            {% assign randomId = "now" | date: "%N" | modulo: 10000 %}
+            {% assign randomId = "now" | date: "%N" | modulo: diff | plus: min %}
             <div id="response-{{ randomId }}"></div>
             <script>
                 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
i tweaked how we are getting random div id's based on [this](https://stackoverflow.com/questions/9053066/sorted-navigation-menu-with-jekyll-and-liquid)

by messing with the modulo value, i was able to generate different id's.  i think this is the intended result of the original code, and everything is correct now in the UI.