### PR TITLE
Observation Create Accepted Units

### DIFF
--- a/collections/_api/observation.md
+++ b/collections/_api/observation.md
@@ -150,7 +150,7 @@ sections:
               | :----------------------------- | :--------- | :----------- | :------------------------ |
               | vital sign panel               | 85353-1    |              |                           |
               | blood pressure                 | 85354-9    | mmHg         |                           |
-              | weight                         | 29463-7    | oz           | lbs, kg                   |
+              | weight                         | 29463-7    | oz           | lb, kg                   |
               | height                         | 8302-2     | in           | cm                        |
               | pulse rate                     | 8867-4     | bpm          |                           |
               | body temperature               | 8310-5     | °F           |                           |


### PR DESCRIPTION
From Dreem:
"I’m now mapping vitals using the Observation endpoint. I wanted to let you know, there is a little typo in your documentation : https://docs.canvasmedical.com/api/observation/#create in “additional accepted units”, it says “lbs”, but this is not accepted by your API, only “lb” worked"