### PR TITLE
add link to api documentation for the consent codings doc

### DIFF
--- a/collections/_api/consent.md
+++ b/collections/_api/consent.md
@@ -68,6 +68,8 @@ sections:
         endpoints: [create, read, search]
         create:
           description: >-
+            Before creating a consent via the API, Patient Consent Codings **must** be [configured in Canvas](/documentation/consents).<br><br>
+
             **Updating existing patient consent objects**<br><br>
 
             A patient consent is uniquely distinguished by its patient and consent coding<br><br>


### PR DESCRIPTION
saw a ticket the other day where someone had an issue with consent codings via the API.  I added a link to that documentation in the Consent Create api page.