### PR TITLE
make create and update return responses more descriptive

### DIFF
--- a/_includes/blocks/block-apidoc-responses-created.html
+++ b/_includes/blocks/block-apidoc-responses-created.html
@@ -4,7 +4,9 @@
     201 Created
   </div>
   <div class="apidoc__object__description">
-    The server has successfully processed the request, the new resource has been created and is now ready for interaction.
+    The server has successfully processed the request; the new resource has been created and is now ready for interaction.<br><br>
+
+    Canvas returns the created resource's id as a UUID within the <code>location</code> header and a <code>null</code> response body.
   </div>
 </div>
 {% endif %}

--- a/_includes/blocks/block-apidoc-responses-updated.html
+++ b/_includes/blocks/block-apidoc-responses-updated.html
@@ -1,0 +1,12 @@
+{% if response == 200 %}
+<div class="apidoc__object">
+  <div class="apidoc__object__name">
+    200 OK
+  </div>
+  <div class="apidoc__object__description">
+    The server has successfully processed the request.<br><br>
+
+    Canvas returns a <code>null</code> response body.
+  </div>
+</div>
+{% endif %}

--- a/_includes/blocks/block-apidoc.html
+++ b/_includes/blocks/block-apidoc.html
@@ -319,7 +319,7 @@
         <div class="apidoc__gridcol">
             <h3>Responses</h3>
             {% for response in block.update.responses %}
-            {% include blocks/block-apidoc-responses-ok.html %}
+            {% include blocks/block-apidoc-responses-updated.html %}
             {% endfor %}
             <h3>Errors</h3>
             {% for response in block.update.responses %}


### PR DESCRIPTION
added some changes to make our return response for Creates and Updates more descriptive.  this stems from a contest question, and I agree that we don't make it clear enough that the resource id is in the location header.  we mention it in the Quickstart but not in the actual API docs themselves.  

I added a template for updated responses as the standard OK template is used for read/search 200 responses as well.

@jrwils please review from a developer standpoint if you can - not sure if saying "we return a null response body" is what other people would expect or not.  

@kristenoneill appreciate your general input on the phrasing as well