### PR TITLE
Adds correspondence to available DocumentReference categories.

### DIFF
--- a/collections/_api/documentreference.md
+++ b/collections/_api/documentreference.md
@@ -31,13 +31,14 @@ sections:
             description: >-
               The categorization of the document. Supported category codes are:<br><br>
               **clinical-note**<br>
+              **correspondence**<br>
               **educationalmaterial**<br>
               **imagingreport**<br>
               **invoicefull**<br>
               **labreport**<br>
               **patientadministrativedocument**<br>
               **referralreport**<br>
-              **uncategorizedclinicaldocument** 
+              **uncategorizedclinicaldocument**
             type: array[json]
           - name: subject
             description: >-


### PR DESCRIPTION
Adds correspondence to available DocumentReference categories. This can go live when the DocumentReference letter additions are released:

JIRA: https://canvasmedical.atlassian.net/browse/KOALA-685
PR: https://github.com/canvas-medical/canvas/pull/15607/
