### PR TITLE
Added documentation for Claim $add-activity-log-item operation

### DIFF
--- a/_includes/blocks/block-apidoc-endpoints.html
+++ b/_includes/blocks/block-apidoc-endpoints.html
@@ -14,3 +14,7 @@
     {% assign method = 'put' %}
     {% assign url = '/{id}' %}
 {% endif %}
+{% if endpoint contains 'operation' %}
+    {% assign method = endpoint.method %}
+    {% assign url = endpoint.url %}
+{% endif %}

--- a/collections/_api/allergen.md
+++ b/collections/_api/allergen.md
@@ -32,7 +32,7 @@ sections:
           example_request: allergen-read-request
           example_response: allergen-read-response
         search:
-          description: Search for Allergyen resources.
+          description: Search for Allergen resources.
           responses: [200, 400, 401, 403]
           example_request: allergen-search-request
           example_response: allergen-search-response

--- a/collections/_api/claim.md
+++ b/collections/_api/claim.md
@@ -100,7 +100,7 @@ sections:
           - name: patient
             type: string
             description: Patient receiving the products or services
-        endpoints: [create, read, update, search]
+        endpoints: [create, read, update, search, operation-add-activity-log-item]
         create:
           description: Create a Claim resource.
           responses: [201, 400, 401, 403, 405, 422]
@@ -122,6 +122,15 @@ sections:
           responses: [200, 400, 401, 403]
           example_request: claim-search-request
           example_response: claim-search-response
+        operation-add-activity-log-item:
+          description: >-
+            Add an activity log item to a Claim.<br><br>
+            This endpoint is a [FHIR operation](https://hl7.org/fhir/R4/operations.html), so it accepts a [Parameters](https://hl7.org/fhir/R4/parameters.html) resource in the request body. It will accept one and only one parameter, which must have the name **comment**. The comment that will be added is provided as a `valueString`. See the request example for more detail.
+          method: post
+          url: /{id}/$add-activity-log-item
+          responses: [201, 400, 401, 403, 404]
+          example_request: claim-operation-add-activity-log-item-request
+          example_response: claim-operation-add-activity-log-item-response
 ---
 
 <div id="claim-create-request">
@@ -1036,4 +1045,63 @@ print(response.text)
 ```
     {% endtab %}
 {% endtabs %}
+</div>
+
+<div id="claim-operation-add-activity-log-item-request">
+
+  {% tabs claim-operation-add-activity-log-item-request %}
+
+    {% tab claim-operation-add-activity-log-item-request curl %}
+```shell
+curl --request POST \
+     --url 'https://fumage-example.canvasmedical.com/Claim/<id>/$add-activity-log-item' \
+     --header 'Authorization: Bearer <token>' \
+     --header 'accept: application/json' \
+     --header 'content-type: application/json' \
+     --data '
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "comment",
+            "valueString": "Test comment"
+        }
+    ]
+}'
+```
+    {% endtab %}
+
+    {% tab claim-update-request python %}
+```python
+import requests
+
+url = "https://fumage-example.canvasmedical.com/Claim/<id>/$add-activity-log-item"
+
+headers = {
+    "accept": "application/json",
+    "Authorization": "Bearer <token>",
+    "content-type": "application/json"
+}
+
+payload = {
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "comment",
+            "valueString": "Test comment"
+        }
+    ]
+}
+response = requests.put(url, json=payload, headers=headers)
+
+print(response.text)
+```
+    {% endtab %}
+
+  {% endtabs %}
+
+</div>
+
+<div id="claim-operation-add-activity-log-item-response">
+{% include update-response.html resource_type="Claim" %}
 </div>


### PR DESCRIPTION
This PR adds documentation for a FHIR operation on the Claim resource that will add an activity log item to a Claim. Ticket: https://canvasmedical.atlassian.net/browse/KOALA-807

**Important note:** The changes in this PR do not currently work, but they illustrated what the desired change is. Some site enhancements are needed to support a new type of FHIR endpoint that diverts from the typical CRUS pattern.

Some differences between FHIR CRUS endpoints and [FHIR operation](https://hl7.org/fhir/R4/operations.html) endpoints:
* There can be any number of operations on a resource.
* The names of of the operation do not follow any pattern. This affects the URLs as well.
* They are almost always executed by POST, and sometimes by GET.

List of things that are not currently working and need attention:
* The URL in the "Endpoints" box on the Claim page doesn't render as desired. It should be `/Claim/{id}/$add-activity-log-item`
* The URL also doesn't render as desired in the operation documentation.
* We need a way to set the heading for the operation documentation to be `Claim $add-activity-log-item`.
* The request example does not appear.
* The response example does not appear.