### PR TITLE
[KOALA-893][BUFIX] CoverageEligibilityResponse Fumage GET Errors & UI Display

### DIFF
--- a/collections/_api/coverageeligibilityresponse.md
+++ b/collections/_api/coverageeligibilityresponse.md
@@ -32,7 +32,7 @@ sections:
             description: CoverageEligibilityRequest reference the elibibility response is for
           - name: outcome
             type: string
-            description: Outcome of the request processing, will always be **"complete"**
+            description: Outcome of the request processing, if an error occurs it will be marked as **"error"** othervise it will be marked as **"complete"**
           - name: insurer
             type: json
             description: >-


### PR DESCRIPTION
Expand CoverageEligibilityResponse outcome filed with new possible value named error.