### PR TITLE
Update language on Coverage status

### DIFF
--- a/collections/_api/coverage.md
+++ b/collections/_api/coverage.md
@@ -20,7 +20,7 @@ sections:
             type: string
           - name: status
             type: enum [ active | cancelled ]
-            description_for_all_endpoints: The status of the Coverage. <br><br>In Canvas, the status of `active` means it appears in the Patient's Profile page either under the main or other coverage sections, while a status of `cancelled` means it was removed and no longer appears on the page. Of note, an expired coverage will still show as `active`, so be sure to set/read the `period.end` attribute.
+            description_for_all_endpoints: The status of the Coverage. <br><br>In Canvas, the status of `active` means it appears in the Patient's Profile page either under the main or other coverage sections, while a status of `cancelled` means it was removed and no longer appears on the page. An expired coverage will still show as `active`, so be sure to set/read the `period.end` attribute.
             create_description: Currently there is no way to create a coverage that appears under the "Other Coverages" section on the Patient Profile. All coverages created with `active` will appear as the primary, secondary, tertiary, etc coverage depending on the order number. Coverages created with a `cancelled` status will not appear on the UI, but can still be read out.
             update_description: If a coverage in the Canvas UI is in the "Other coverages" section, on an update if the status stays `active`, it will remain in the "Other coverages" section.
             required_in: create,update


### PR DESCRIPTION
There was some customer confusion on the Canvas stack field to FHIR Status so I added some clarity since we only documented it in the release notes. Related SUP ticket is: https://canvasmedical.atlassian.net/browse/SUP-901