### PR TITLE
Specialty coding in DocumentReference for Referral Report documents

### DIFF
--- a/collections/_api/documentreference.md
+++ b/collections/_api/documentreference.md
@@ -369,7 +369,7 @@ sections:
                 create_description: >- 
                   Specialty coding.
                   <br><br>
-                  **Required** for DocumentReferences of **referralreprt** for `category -> 0 -> coding -> 0 -> code`. Use to determine the Specialty on the documents of the category type 'referralreport'. Use the following value set for reference - <a href="https://hl7.org/fhir/R4/valueset-c80-practice-codes.html" target="_blank">https://hl7.org/fhir/R4/valueset-c80-practice-codes.html</a>
+                  **Required** for DocumentReferences with a `category.coding.code` of **referralreprt**. Use to determine the Specialty on the documents of the category type 'referralreport'. Use [this value set for reference](https://hl7.org/fhir/R4/valueset-c80-practice-codes.html).
                 attributes:
                   - name: coding
                     type: array[json]


### PR DESCRIPTION
Linked Issue
------------

[KOALA-734](https://canvasmedical.atlassian.net/browse/KOALA-734)

Related Canvas PR - https://github.com/canvas-medical/canvas/pull/16358
Related Fumage PR - https://github.com/canvas-medical/fumage/pull/719

Description
-----------

When creating a Document Reference record for the documents of type Referral Report, providing a specialty is required. 
On the Document Reference resource, we decided to use the `practiceSetting` coding property for the specialty.

[KOALA-734]: https://canvasmedical.atlassian.net/browse/KOALA-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ