### PR TITLE
Adds TASK_COMPLETED and TASK_CLOSED events.

### DIFF
--- a/collections/_sdk/events.md
+++ b/collections/_sdk/events.md
@@ -636,6 +636,14 @@ These events fire as a result of records being created, updated, or deleted.
       <td>TASK_LABELS_ADJUSTED</td>
       <td>Occurs when a task's labels are changed.</td>
     </tr>
+    <tr>
+      <td>TASK_COMPLETED</td>
+      <td>Occurs when a task is set to completed.</td>
+    </tr>
+    <tr>
+      <td>TASK_CLOSED</td>
+      <td>Occurs when a task is set to closed.</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2252
https://canvasmedical.atlassian.net/browse/KOALA-2251

Adds new `TASK_COMPLETED` and `TASK_CLOSED` events to documentation.