### PR TITLE
[sdk] remove prescribe from list of supported protocol card recommendations for the new sdk

### DIFF
--- a/collections/_sdk/effects/protocol_cards.md
+++ b/collections/_sdk/effects/protocol_cards.md
@@ -146,6 +146,5 @@ Only the following commands from the [commands module](/sdk/commands/) are curre
 - MedicationStatement
 - Perform
 - Plan
-- Prescribe
 - Questionnaire
 - ReasonForVisit


### PR DESCRIPTION
this is temporary until we can find a way to support both. 