### PR TITLE
[KOALA-2520] Update commands module to support supervising provider in plugins

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -93,6 +93,7 @@ AdjustPrescriptionCommand(
     substitutions=PrescribeCommand.Substitutions.ALLOWED,
     pharmacy="Main Street Pharmacy",
     prescriber_id="provider_123",
+    supervising_provider_id="provider_456",
     note_to_pharmacist="Please verify patient's insurance before processing."
 )
 ```
@@ -679,19 +680,20 @@ plan = PlanCommand(
 
 **Command-specific parameters**:
 
-| Name                   | Type                          | Required | Description                                                        |
-|------------------------|-------------------------------|----------|--------------------------------------------------------------------|
-| `fdb_code`             | _string_                      | `true`   | FDB code for the medication.                                       |
-| `icd10_codes`          | _list[string]_                | `false`  | List of ICD-10 codes (maximum 2) associated with the prescription. |
-| `sig`                  | _string_                      | `true`   | Administration instructions/details of the medication.             |
-| `days_supply`          | _integer_                     | `false`  | Number of days the prescription is intended to cover.              |
-| `quantity_to_dispense` | _Decimal \| float \| integer_ | `true`   | The amount of medication to dispense.                              |
-| `type_to_dispense`     | _ClinicalQuantity_            | `true`   | Information about the form or unit of the medication to dispense.  |
-| `refills`              | _integer_                     | `true`   | Number of refills allowed for the prescription.                    |
-| `substitutions`        | _Substitutions Enum_          | `true`   | Specifies whether substitutions (e.g., generic drugs) are allowed. |
-| `pharmacy`             | _string_                      | `false`  | The NCPDP ID of the pharmacy where the prescription should be sent.    |
-| `prescriber_id`        | _string_                      | `true`   | The key of the prescriber.                     |
-| `note_to_pharmacist`   | _string_                      | `false`  | Additional notes or instructions for the pharmacist.               |
+| Name                      | Type                          | Required | Description                                                        |
+|---------------------------|-------------------------------|----------|--------------------------------------------------------------------|
+| `fdb_code`                | _string_                      | `true`   | FDB code for the medication.                                       |
+| `icd10_codes`             | _list[string]_                | `false`  | List of ICD-10 codes (maximum 2) associated with the prescription. |
+| `sig`                     | _string_                      | `true`   | Administration instructions/details of the medication.             |
+| `days_supply`             | _integer_                     | `false`  | Number of days the prescription is intended to cover.              |
+| `quantity_to_dispense`    | _Decimal \| float \| integer_ | `true`   | The amount of medication to dispense.                              |
+| `type_to_dispense`        | _ClinicalQuantity_            | `true`   | Information about the form or unit of the medication to dispense.  |
+| `refills`                 | _integer_                     | `true`   | Number of refills allowed for the prescription.                    |
+| `substitutions`           | _Substitutions Enum_          | `true`   | Specifies whether substitutions (e.g., generic drugs) are allowed. |
+| `pharmacy`                | _string_                      | `false`  | The NCPDP ID of the pharmacy where the prescription should be sent. |
+| `prescriber_id`           | _string_                      | `true`   | The key of the prescriber.                                         |
+| `supervising_provider_id` | _string_                      | `true`   | The key of the supervising provider.                               |
+| `note_to_pharmacist`      | _string_                      | `false`  | Additional notes or instructions for the pharmacist.               |
 
 **Enums and Types**
 
@@ -730,6 +732,7 @@ prescription = PrescribeCommand(
     substitutions=PrescribeCommand.Substitutions.ALLOWED,
     pharmacy="Main Street Pharmacy",
     prescriber_id="provider_123",
+    supervising_provider_id="provider_456",
     note_to_pharmacist="Please verify patient's insurance before processing."
 )
 ```
@@ -1005,6 +1008,7 @@ RefillCommand(
     substitutions=PrescribeCommand.Substitutions.ALLOWED,
     pharmacy="Main Street Pharmacy",
     prescriber_id="provider_123",
+    supervising_provider_id="provider_456",
     note_to_pharmacist="Please verify patient's insurance before processing."
 )
 ```


### PR DESCRIPTION
Linked Issue
------------
https://canvasmedical.atlassian.net/browse/PANDA-189

Description
-----------

Plugins have the ability to [create and edit Prescribe and Refill commands](https://docs.canvasmedical.com/sdk/commands/#prescribe). There is also the ability to add a [recommendation in a protocol card](https://docs.canvasmedical.com/sdk/effect-protocol-cards/) for a prescribe command. Both of these use the same command fields. We need to add the ability to set the supervising provider in these workflows


Step one updating the interpreter for creating/update prescribe commands in plugins. Seems like refill and adjust prescription inherit from these already. 

So we need to add the supervising_provider_id to https://github.com/canvas-medical/canvas-plugins/blob/main/canvas_sdk/commands/commands/prescribe.py#L10  see how the prescriber_id is now

Then we need a supervising_provider_idto https://github.com/canvas-medical/canvas/blob/develop/home-app/plugin_io/interpreters/commands/prescribe.py#L131  see how the prescriber_id is now but we do not need to show the EPCS next to the provider name, full name is fine
These will then feed into the work you did in https://canvasmedical.atlassian.net/browse/KOALA-2518 . You should be able to write a protocol that edit or originate a prescribe, refill, adjust prescription with that field set. See https://docs.canvasmedical.com/sdk/commands/#methods  

Step two is also update if it came in as a protocol recommendation card. This you can write a protocol using https://docs.canvasmedical.com/sdk/effect-protocol-cards/ . But the code to update is _resolve_prescribe function in https://github.com/canvas-medical/canvas/blob/develop/home-app/api/graphql/protocol/types.py#L787  to set the supervising provider. Only set this if it comes in the payload, if not leave it blank, there should be no default value like prescriber_id has 

We will also need to update documentation for places linked above with this new field
