### PR TITLE
Fix search param name

### DIFF
--- a/collections/_api/slot.md
+++ b/collections/_api/slot.md
@@ -52,8 +52,8 @@ sections:
             type: date
             description: >-
               If included, the request will search for available appointment slots on or after this date. If not included, the current UTC date will be used.
-          - name: appointmentType
-            description: Filters by the code and/or system of the allowed appointment type (if specificied in admin). You can search by just the code value or you can search by the system and code in the format `system|code` (e.g `http://snomed.info/sct|185418009`).
+          - name: appointment-type
+            description: Filters by the code and system of the allowed appointment type (if specificied in admin). Use the format `system|code` (e.g `http://snomed.info/sct|185418009`).
             type: string
         endpoints: [search]
         search:


### PR DESCRIPTION
Was listed as `appointmentType`, but is actually `appointment-type`.