### PR TITLE
Fix plugin example generation

### DIFF
--- a/.github/workflows/generate-example-plugin-docs.yml
+++ b/.github/workflows/generate-example-plugin-docs.yml
@@ -41,4 +41,7 @@ jobs:
           title: Generate Example Plugin Docs
           commit-message: "Generate docs for recently changed example plugins"
           body: |
-            Generate docs for recently changed example plugins
+            ## TODO
+            - [ ] Remove redundant header if the plugin's readme also specifies a header
+            - [ ] Review content for accuracy and edit to seem a little less generated. Make sure the content is actually useful and relevant. Remember, this is just a starting point.
+            - [ ] Add an entry to `_data/menus.yml` (This could be automated, but it would resort every list in that file, which is not desireable.)

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -524,6 +524,9 @@ sdk:
 sdk_overview:
  - title: "Introduction"
    url: /sdk/
+ - title: "Example Plugins"
+   url: /sdk/examples/
+   identifier: example_plugins
  - title: "Caching Module"
    url: /sdk/caching/
  - title: "Command Line Interface"
@@ -553,6 +556,14 @@ sdk_overview:
    url: /sdk/utils/
  - title: "Testing Utilities"
    url: /sdk/testing-utils/
+
+example_plugins:
+  - title: "API Samples"
+    url: /sdk/example-api_samples/
+  - title: "Charting API Examples"
+    url: /sdk/example-charting_api_examples/
+  - title: "Example Patient Portal Page"
+    url: /sdk/example-example_patient_portal_page/
 
 sdk_handlers:
   - title: "Action Buttons"

--- a/collections/_sdk/examples.md
+++ b/collections/_sdk/examples.md
@@ -1,0 +1,22 @@
+---
+title: "Example Plugins"
+disable_anchorlist: true
+---
+
+The pages below showcase example plugins written with the Canvas SDK. All
+pages describe the file structure, the functionality, and link to GitHub where
+you can grab the code yourself and start iterating.
+
+<div class="sdk-card-list">
+{% for item in site.menus.example_plugins %}
+    <a href="{{ item.url }}">
+        <div class="sdk-card">
+            <span class="cardHeading">{{ item.title }}</span>
+        </div>
+    </a>
+{% endfor %}
+</div>
+
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/examples/api_samples.md
+++ b/collections/_sdk/examples/api_samples.md
@@ -1,0 +1,162 @@
+---
+title: 'API Samples'
+slug: 'example-api_samples'
+---
+
+{% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/api_samples' target='_blank'>View the source</a> for this plugin on GitHub." %}
+
+Showcases the usage of the SimpleAPI handler
+
+## Configuration
+
+Once installed, see the plugin configuration page to set credentials to make
+authenticated requests.
+
+## CANVAS_MANIFEST.json
+
+```json
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "api_samples",
+    "description": "Example usages of the SimpleAPI handler",
+    "components": {
+        "protocols": [
+            {
+                "class": "api_samples.routes.hello_world:HelloWorldAPI",
+                "description": "Returns a json message",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            },
+            {
+                "class": "api_samples.routes.email_bounce:EmailBounceAPI",
+                "description": "Creates a task to confirm patient contact info",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": ["my-api-key"],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}
+```
+
+## routes/
+
+### email_bounce.py
+
+The code defines an endpoint for handling bounced email events.
+
+**Endpoint**
+
+- **Path:** `/crm-webhooks/email-bounce`
+- **Method:** POST
+- **Expected Body:** JSON containing `{"mrn": "valid patient MRN"}`
+- **Authorization:** Requires an API key in the `Authorization` header that matches the plugin secret `'my-api-key'`.
+
+**Core Functionality**
+
+- When a POST request is received:
+  - It authenticates the request by verifying the provided API key against a stored secret.
+  - It retrieves the `Patient` object from the database with the given MRN (Medical Record Number) from the request body.
+  - It schedules a new open task for that patient:
+    - **Title:** `"Please confirm contact information."`
+    - **Due Date:** 5 days from the current UTC date
+    - **Label:** `"CRM"`
+- Returns a response indicating both the creation of the task and a confirmation JSON message.
+
+**Intended Use**
+
+This endpoint provides an automated workflow to prompt staff to confirm and update patient contact information in response to an email bounce event, improving contact data quality in clinical operations.
+
+```python
+import arrow
+
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.effects.task import AddTask, TaskStatus
+from canvas_sdk.handlers.simple_api import APIKeyCredentials, SimpleAPIRoute
+from canvas_sdk.v1.data import Patient
+
+#
+# POST /plugin-io/api/api_samples/crm-webhooks/email-bounce
+# Body: { "mrn": "valid patient MRN" }
+# Headers: "Authorization <your value for 'my-api-key'>"
+#
+
+
+class EmailBounceAPI(SimpleAPIRoute):
+    PATH = "/crm-webhooks/email-bounce"
+
+    def authenticate(self, credentials: APIKeyCredentials) -> bool:
+        return credentials.key == self.secrets["my-api-key"]
+
+    def post(self) -> list[Response]:
+        patient = Patient.objects.get(mrn=self.request.json()["mrn"])
+        five_days_from_now = arrow.utcnow().shift(days=5).datetime
+
+        task_effect = AddTask(
+            patient_id=patient.id,
+            title="Please confirm contact information.",
+            due=five_days_from_now,
+            status=TaskStatus.OPEN,
+            labels=["CRM"],
+        )
+
+        return [task_effect.apply(), JSONResponse({"message": "Task Created"})]
+```
+
+### hello_world.py
+
+This code defines a simple API endpoint which handles requests to the path `/hello-world`. When a GET request is made to this endpoint, the API responds with a JSON message that says "Hello world!".
+
+**Authentication**
+
+The endpoint requires an API key for authentication. The client must provide an API key (as a header called `Authorization`). The provided key is compared to a value stored in `self.secrets["my-api-key"]`. If the keys match, authentication is successful and the request is allowed; otherwise, it will be denied.
+
+**Response**
+
+A GET request to `/plugin-io/api/api_samples/hello-world` (when authenticated) returns a JSON response in the following format:
+
+```json
+{
+  "message": "Hello world!"
+}
+```
+
+```python
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyCredentials, SimpleAPIRoute
+
+#
+# GET /plugin-io/api/api_samples/hello-world
+# Headers: "Authorization <your value for 'my-api-key'>"
+#
+
+
+class HelloWorldAPI(SimpleAPIRoute):
+    PATH = "/hello-world"
+
+    def authenticate(self, credentials: APIKeyCredentials) -> bool:
+        return credentials.key == self.secrets["my-api-key"]
+
+    def get(self) -> list[Response]:
+        return [JSONResponse({"message": "Hello world!"})]
+```
+
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/examples/charting_api_examples.md
+++ b/collections/_sdk/examples/charting_api_examples.md
@@ -1,0 +1,778 @@
+---
+title: 'Charting API Examples'
+slug: 'example-charting_api_examples'
+---
+
+{% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/charting_api_examples' target='_blank'>View the source</a> for this plugin on GitHub." %}
+
+This example plugin provides several examples of APIs you might define when
+automating charting in Canvas.
+
+- Notes
+  - Creating a note
+  - Getting information about a note
+  - Searching for notes by patient, type, and date of service
+  - Adding billing line items to a note
+- Commands
+  - Creating a command
+  - Creating multiple commands from a single request
+  - Creating a command and committing it in a single request
+
+## Configuration
+
+All of the example endpoints in this plugin are protected with [API key
+authentication](https://docs.canvasmedical.com/sdk/handlers-simple-api-http/#api-key-1).
+Once installed, you'll need to set the `simpleapi-api-key` value on the plugin's
+configuration page in your EHR.
+
+## Endpoint Documentation
+
+### Search Notes
+
+`GET /plugin-io/api/charting_api_examples/notes/`
+
+This endpoint allows the retrieval of an optionally filtered set of notes. The results are paginated, and the client can exert some control over the page size. The response body will include an attribute, `next_page`, which will either contain a URL to the next page of the same filtered set or be `null`, indicating there are no more records to fetch.
+
+#### Optional query parameters:
+
+##### limit
+
+*int*
+
+Determines the number of results to return per page.
+
+- If unspecified, the default is 10.
+- If a number less than 1 is specified, 1 will be used.
+- If a number greate than 100 is specified, 100 will be used.
+
+##### offset
+
+*int*
+
+Number of records to skip with returning results. When used with **limit**, this enables the pagination of results.
+
+- If unspecified, the default is 0.
+- If a number less than 0 is specified, 0 will be used.
+
+
+##### patient_id
+
+*str*
+
+Filters the notes returned to just those associated with the given patient.
+
+##### note_type
+
+*coding*
+
+You can search by just the code value or you can search by the
+system and code in the format "system|code" (e.g. `http://snomed.info/sct|308335008`).
+
+##### datetime_of_service
+
+*iso8601 formatted datetime string*
+
+Exact match for notes with the given datetime.
+
+##### datetime_of_service__gt
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring after the given datetime.
+
+##### datetime_of_service__gte
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring at or after the given datetime.
+
+##### datetime_of_service__lt
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring before the given datetime.
+
+##### datetime_of_service__lte
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring at or before the given datetime.
+
+#### Example Request
+
+```bash
+curl --request GET \
+  --url 'https://training.canvasmedical.com/plugin-io/api/charting_api_examples/notes/?limit=2&offset=4' \
+  --header 'Authorization: <your-api-key-goes-here>'
+```
+
+#### Example Response
+
+```json
+{
+  "next_page": "https://training.canvasmedical.com/plugin-io/api/charting_api_examples/notes/?limit=2&offset=6",
+  "count": 2,
+  "notes": [
+    {
+      "id": "10ff2047-6301-4ab4-81cd-b500e7df8ef7",
+      "patient_id": "5350cd20de8a470aa570a852859ac87e",
+      "provider_id": "5843991a8c934118ab4f424c839b340f",
+      "datetime_of_service": "2025-02-21 23:31:45.627894+00:00",
+      "note_type": {
+        "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+        "name": "Office visit",
+        "coding": {
+          "display": "Office Visit",
+          "code": "308335008",
+          "system": "http://snomed.info/sct"
+        }
+      }
+    },
+    {
+      "id": "4dba128f-96cc-4dd0-814b-a064bfdcde7e",
+      "patient_id": "5350cd20de8a470aa570a852859ac87e",
+      "provider_id": "336159560091471cb6b0e149d9054697",
+      "datetime_of_service": "2025-02-21 23:31:45.928071+00:00",
+      "note_type": {
+        "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+        "name": "Office visit",
+        "coding": {
+          "display": "Office Visit",
+          "code": "308335008",
+          "system": "http://snomed.info/sct"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Read a Note
+
+`GET /plugin-io/api/charting_api_examples/notes/<note-id>/`
+
+#### Example Response
+
+```json
+{
+  "note": {
+    "id": "1490b8db-00a9-47d9-9170-ec142460b586",
+    "patient_id": "5350cd20de8a470aa570a852859ac87e",
+    "provider_id": "6b33e69474234f299a56d480b03476d3",
+    "datetime_of_service": "2025-10-02 23:30:00+00:00",
+    "state": "NEW",
+    "note_type": {
+      "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+      "name": "Office visit",
+      "coding": {
+        "display": "Office Visit",
+        "code": "308335008",
+        "system": "http://snomed.info/sct"
+      }
+    }
+  }
+}
+```
+
+### Create a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/`
+
+#### Example Request Body
+
+```json
+{
+  "practice_location_id": "306b19f0-231a-4cd4-ad2d-a55c885fd9f8",
+  "note_type_id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+  "patient_id": "5350cd20de8a470aa570a852859ac87e",
+  "provider_id": "6b33e69474234f299a56d480b03476d3",
+  "datetime_of_service": "2025-10-04 23:30:00",
+  "title": "My cool note"
+}
+```
+
+### Add Billing Line Item to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/billing_line_items/`
+
+#### Example Request Body
+
+```json
+{
+  "cpt_code": "98008"
+}
+```
+
+### Add a Diagnose Command to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/diagnose/`
+
+`icd10_code` is required, but `committed` may be true, false, or omitted entirely.
+
+#### Example Request Body
+
+```json
+{
+  "icd10_code": "E119",
+  "committed": true
+}
+```
+
+### Add Multiple Commands to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/prechart/`
+
+#### Example Request Body
+
+```json
+null
+```
+
+## CANVAS_MANIFEST.json
+
+```json
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "charting_api_examples",
+    "description": "A series of custom API routes that showcase SDK charting functionality",
+    "components": {
+        "protocols": [
+            {
+                "class": "charting_api_examples.routes.notes:NoteAPI",
+                "description": "Endpoints that showcase interactions with notes.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            },
+            {
+                "class": "charting_api_examples.routes.billing_line_items:BillingLineItemAPI",
+                "description": "Endpoints for interacting with billing line items on a note.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            },
+            {
+                "class": "charting_api_examples.routes.commands:CommandAPI",
+                "description": "Endpoints for interacting with commands on a note.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": ["simpleapi-api-key"],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}
+```
+
+## routes/
+
+### commands.py
+
+This file provides an example of how to define REST API endpoints in a Canvas-based plugin for inserting medical charting commands to clinical notes, with validation, error handling, and support for both single and batch command operations.
+
+**Endpoints**
+
+1. `/notes/<id>/diagnose/` (POST):  
+   - Adds a DiagnoseCommand to the specified note.
+   - Expects a JSON body with at least an "icd10_code" parameter, and optionally "committed" (boolean).
+   - If "committed" is true, the diagnose command is also committed immediately after being originated.
+   - Handles missing attribute errors and note-not-found situations gracefully, responding with appropriate error messages and status codes.
+
+2. `/notes/<id>/prechart/` (POST):  
+   - Initiates (originates) several commands at once for a note: ReasonForVisitCommand, PhysicalExamCommand, DiagnoseCommand, and PlanCommand.
+   - Designed to quickly set up the structure for clinical pre-charting with a single request.
+
+**Implementation Highlights**
+
+- The API is protected with API key authentication via `APIKeyAuthMixin`.
+- Uses utility functions (`get_note_from_path_params`, `note_not_found_response`) to locate notes and standardize error responses.
+- Returns both command effects (operations that are intended to be executed in the Canvas system) and standard JSON responses.
+- Uses status codes according to best practices, addressing Python version differences by using explicit numeric codes where needed.
+
+**Canvas SDK Features Used**
+
+- Commands: `DiagnoseCommand`, `PhysicalExamCommand`, `PlanCommand`, `ReasonForVisitCommand` — each representing an action to be performed on a note.
+- Effects: Chainable "originate" (create/begin the command) and "commit" (finalize/commit the command).
+
+
+```python
+from http import HTTPStatus
+from uuid import uuid4
+
+from canvas_sdk.commands import (
+    DiagnoseCommand,
+    PhysicalExamCommand,
+    PlanCommand,
+    ReasonForVisitCommand,
+)
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note
+
+from charting_api_examples.util import get_note_from_path_params, note_not_found_response
+
+
+class CommandAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    This shows how you can create an endpoint to insert a particular type of
+    command. In this example, it's a diagnose command. It can be committed or
+    left uncommitted.
+
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/diagnose/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+        "icd10_code": "E11.9",
+        "committed": false
+    }
+    """
+    @api.post("/<id>/diagnose/")
+    def add_diagnose_command(self) -> list[Response | Effect]:
+        required_attributes = {"icd10_code",}
+        request_body = self.request.json()
+        missing_attributes = required_attributes - request_body.keys()
+        if len(missing_attributes) > 0:
+            return [
+                JSONResponse(
+                    {"error": f"Missing required attribute(s): {', '.join(missing_attributes)}"},
+                    # Normally you should use a constant, but this status
+                    # code's constant changes in 3.13 from
+                    # UNPROCESSABLE_ENTITY to UNPROCESSABLE_CONTENT. Using the
+                    # number directly here avoids that future breakage.
+                    status_code=422,
+                )
+            ]
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        diagnose_command = DiagnoseCommand(
+            note_uuid=str(note.id),
+            icd10_code=request_body["icd10_code"].upper(),
+        )
+
+        if request_body.get("committed"):
+            # To chain command effects, you must know what the command's id
+            # is. To accomplish that, we set the id ourselves rather than
+            # allow the database to assign one.
+            diagnose_command.command_uuid = str(uuid4())
+            command_effects = [diagnose_command.originate(), diagnose_command.commit()]
+        else:
+            command_effects = [diagnose_command.originate()]
+
+        return [
+            *command_effects,
+            JSONResponse({"message": "Command data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]
+
+    """
+    This shows how you can originate many commands from the same request.
+
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/prechart/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+    }
+    """
+    @api.post("/<id>/prechart/")
+    def add_precharting_commands(self) -> list[Response | Effect]:
+        request_body = self.request.json()
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        rfv = ReasonForVisitCommand(note_uuid=str(note.id))
+        exam = PhysicalExamCommand(note_uuid=str(note.id))
+        diagnose = DiagnoseCommand(note_uuid=str(note.id))
+        plan = PlanCommand(note_uuid=str(note.id))
+        return [
+            rfv.originate(),
+            exam.originate(),
+            diagnose.originate(),
+            plan.originate(),
+            JSONResponse({"message": "Command data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]
+```
+
+### notes.py
+
+Defines an API endpoint for working with clinical notes. The API supports listing, creating, and retrieving notes, with filtering and pagination features. Authentication is handled through an API key.
+
+**Endpoints**
+
+- **GET /notes/**
+  - Returns a paginated list of notes.
+  - Supports filters:
+    - `patient_id`: Filter notes for a specific patient.
+    - `note_type`: Filter by note type (by code or by system|code).
+    - `datetime_of_service`, `datetime_of_service__gt`, `datetime_of_service__gte`, `datetime_of_service__lt`, `datetime_of_service__lte`: Date/time based filters.
+  - Pagination:
+    - `limit`: Number of results (default 10, min 1, max 100).
+    - `offset`: Pagination offset (default 0, min 0).
+  - If more results exist after the current page, a `next_page` link is included.
+  - Returns a JSON object with `notes` (list), `count` (number of notes returned), and `next_page` (URL or None).
+
+- **POST /notes/**
+  - Creates a new note.
+  - Requires a JSON body with:
+    - `note_type_id`, `datetime_of_service` (as string), `patient_id`, `practice_location_id`, `provider_id`, `title`
+  - If required fields are missing, returns an error with status 422.
+  - Otherwise, initiates note creation and immediately returns an accepted response (`202 Accepted`) with a confirmation message.
+
+- **GET /notes/\<note-id\>/**
+  - Returns details for a specific note by its ID.
+  - If the note doesn't exist, returns a "not found" response.
+  - If found, returns note details, including its state (from `CurrentNoteStateEvent`), patient/provider IDs, datetime, and type info (id, name, coding).
+
+**Helpers and Utilities**
+
+- Uses utilities such as `get_note_from_path_params` and `note_not_found_response` for ID lookup and error handling.
+- Uses Django-style ORM filters and queryset slicing.
+- Uses the `arrow` library for date parsing.
+- All endpoints expect authentication via the `simpleapi-api-key`.
+
+
+```python
+import arrow
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.note.note import Note as NoteEffect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note, CurrentNoteStateEvent
+
+from charting_api_examples.util import get_note_from_path_params, note_not_found_response
+
+class NoteAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    GET /plugin-io/api/charting_api_examples/notes/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    """
+    @api.get("/")
+    def index(self) -> list[Response | Effect]:
+        notes = Note.objects.select_related('patient', 'provider', 'note_type_version').order_by("dbid")
+        query_params = self.request.query_params
+
+        # User specified, default 10, min 1, max 100
+        limit = min(max(int(query_params.get("limit", 10)), 1), 100)
+        # User specified, default 0, min 0, no max
+        offset = max(int(query_params.get("offset", 0)), 0)
+
+        if "patient_id" in query_params:
+            notes = notes.filter(patient__id=query_params["patient_id"])
+        if "note_type" in query_params:
+            # You can search by just the code value or you can search by the
+            # system and code in the format system|code (e.g
+            # http://snomed.info/sct|308335008).
+            if "|" in query_params["note_type"]:
+                system, code = query_params["note_type"].split("|")
+                notes = notes.filter(note_type_version__system=system, note_type_version__code=code)
+            else:
+                notes = notes.filter(note_type_version__code=query_params["note_type"])
+        if "datetime_of_service" in query_params:
+            notes = notes.filter(datetime_of_service=query_params["datetime_of_service"])
+        if "datetime_of_service__gt" in query_params:
+            notes = notes.filter(datetime_of_service__gt=query_params["datetime_of_service__gt"])
+        if "datetime_of_service__gte" in query_params:
+            notes = notes.filter(datetime_of_service__gte=query_params["datetime_of_service__gte"])
+        if "datetime_of_service__lt" in query_params:
+            notes = notes.filter(datetime_of_service__lt=query_params["datetime_of_service__lt"])
+        if "datetime_of_service__lte" in query_params:
+            notes = notes.filter(datetime_of_service__lte=query_params["datetime_of_service__lte"])
+
+        # If there are more results matching the filter after the ones we're
+        # returning, provide the link to the next page with the proper offset.
+        # If there aren't any more results, return None so the client can tell
+        # that there are no more results to fetch.
+        link_to_next = None
+        if notes[offset+limit:].count() > 0:
+            requested_uri = self.context.get("absolute_uri")
+            if "offset" in query_params:
+                link_to_next = requested_uri.replace(f"offset={offset}", f"offset={offset+limit}")
+            else:
+                param_separator = "?" if len(query_params) == 0 else "&"
+                link_to_next = requested_uri + f"{param_separator}offset={offset+limit}"
+
+        # Apply limit and offset
+        notes = notes[offset:offset+limit]
+
+        count = len(notes)
+        return [
+            JSONResponse({
+                "next_page": link_to_next,
+                "count": count,
+                "notes": [{
+                    "id": str(note.id),
+                    "patient_id": str(note.patient.id),
+                    "provider_id": str(note.provider.id),
+                    "datetime_of_service": str(note.datetime_of_service),
+                    "note_type": {
+                        "id": str(note.note_type_version.id),
+                        "name": note.note_type_version.name,
+                        "coding": {
+                            "display": note.note_type_version.display,
+                            "code": note.note_type_version.code,
+                            "system": note.note_type_version.system,
+                        },
+                    },
+                } for note in notes]
+            })
+        ]
+
+    """
+    POST /plugin-io/api/charting_api_examples/notes/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+		"note_type_id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+        "datetime_of_service": "2025-02-21 23:31:42",
+		"patient_id": "5350cd20de8a470aa570a852859ac87e",
+		"practice_location_id": "306b19f0-231a-4cd4-ad2d-a55c885fd9f8",
+		"provider_id": "6b33e69474234f299a56d480b03476d3",
+		"title": "My Note Title",
+    }
+    """
+    @api.post("/")
+    def create(self) -> list[Response | Effect]:
+        required_attributes = {
+            "note_type_id",
+            "datetime_of_service",
+            "patient_id",
+            "practice_location_id",
+            "provider_id",
+            "title",
+        }
+        request_body = self.request.json()
+        missing_attributes = required_attributes - request_body.keys()
+        if len(missing_attributes) > 0:
+            return [
+                JSONResponse(
+                    {"error": f"Missing required attribute(s): {', '.join(missing_attributes)}"},
+                    # Normally you should use a constant, but this status
+                    # code's constant changes in 3.13 from
+                    # UNPROCESSABLE_ENTITY to UNPROCESSABLE_CONTENT. Using the
+                    # number directly here avoids that future breakage.
+                    status_code=422,
+                )
+            ]
+
+        note_type_id = request_body["note_type_id"]
+        datetime_of_service = arrow.get(request_body["datetime_of_service"]).datetime
+        patient_id = request_body["patient_id"]
+        practice_location_id = request_body["practice_location_id"]
+        provider_id = request_body["provider_id"]
+        title = request_body["title"]
+
+        note_effect = NoteEffect(
+            note_type_id=note_type_id,
+            datetime_of_service=datetime_of_service,
+            patient_id=patient_id,
+            practice_location_id=practice_location_id,
+            provider_id=provider_id,
+            title=title,
+        )
+
+        return [
+            note_effect.create(),
+            JSONResponse({"message": "Note data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]
+
+    """
+    GET /plugin-io/api/charting_api_examples/notes/<note-id>/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    """
+    @api.get("/<id>/")
+    def read(self) -> list[Response | Effect]:
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        status_code = HTTPStatus.OK
+        current_note_state = CurrentNoteStateEvent.objects.get(note=note).state
+        response = {
+            "note": {
+                "id": str(note.id),
+                "patient_id": str(note.patient.id),
+                "provider_id": str(note.provider.id),
+                "datetime_of_service": str(note.datetime_of_service),
+                "state": current_note_state,
+                "note_type": {
+                    "id": str(note.note_type_version.id),
+                    "name": note.note_type_version.name,
+                    "coding": {
+                        "display": note.note_type_version.display,
+                        "code": note.note_type_version.code,
+                        "system": note.note_type_version.system,
+                    },
+                },
+            },
+        }
+
+        return [JSONResponse(response, status_code=status_code)]
+```
+
+### billing_line_items.py
+
+This file defines an API endpoint for adding billing line items (represented by CPT codes) to a note.
+
+**Key Components**
+
+- Imports utility and SDK classes for effects, API handling, and response generation.
+- Defines a class, `BillingLineItemAPI`, which inherits API authentication and handling functionalities.
+- Registers an HTTP POST endpoint at `/notes/<note-id>/billing_line_items/`.
+- Expects an API key in the request header for authentication.
+- Expects the request body to be JSON with a "cpt_code" attribute.
+
+```python
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.billing_line_item import AddBillingLineItem
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note
+
+from charting_api_examples.util import get_note_from_path_params, note_not_found_response
+
+
+class BillingLineItemAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/billing_line_items/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+        "cpt_code": "98006"
+    }
+    """
+    @api.post("/<id>/billing_line_items/")
+    def add_billing_line_item(self) -> list[Response | Effect]:
+        required_attributes = {"cpt_code",}
+        request_body = self.request.json()
+        missing_attributes = required_attributes - request_body.keys()
+        if len(missing_attributes) > 0:
+            return [
+                JSONResponse(
+                    {"error": f"Missing required attribute(s): {', '.join(missing_attributes)}"},
+                    # Normally you should use a constant, but this status
+                    # code's constant changes in 3.13 from
+                    # UNPROCESSABLE_ENTITY to UNPROCESSABLE_CONTENT. Using the
+                    # number directly here avoids that future breakage.
+                    status_code=422,
+                )
+            ]
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        # To see what else you can do with billing line items, visit our docs:
+        # https://docs.canvasmedical.com/sdk/effect-billing-line-items/#adding-a-billing-line-item
+        effect = AddBillingLineItem(
+            note_id=str(note.id),
+            cpt=request_body["cpt_code"],
+        )
+
+        return [
+            effect.apply(),
+            JSONResponse({"message": "Billing line item data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]
+```
+
+## util.py
+
+This file provides utility functions for working with Note objects. The utilities include input validation, standard JSON error responses, and fetching Note objects by ID.
+
+
+**Function: is_valid_uuid**
+
+This function checks whether a given string is a valid UUID (specifically version 4).  
+- Takes a single string argument.
+- Returns True if the string is a properly formatted version 4 UUID, False otherwise.
+
+
+**Function: note_not_found_response**
+
+This function returns a standardized JSON error response indicating that a requested Note was not found.  
+- Uses JSONResponse from the SDK.
+- Sets the response status to HTTP 404 (NOT FOUND) and the body to {"error": "Note not found."}.
+
+
+**Function: get_note_from_path_params**
+
+This function attempts to retrieve a Note object using a dictionary of path parameters.  
+- Extracts the "id" from path_params.
+- Validates the ID as a UUID using is_valid_uuid.
+- If invalid, returns None.
+- If valid, attempts to retrieve a Note object with the given ID (using Note.objects.get).
+- If the Note does not exist, catches the DoesNotExist exception and returns None.
+- Returns the Note object if found, or None if not found/invalid.
+
+
+**Imports and External Dependencies**
+
+- uuid.UUID: For validating UUIDs.
+- http.HTTPStatus: For standardized HTTP status codes.
+- canvas_sdk.effects.simple_api.JSONResponse: For returning consistent API responses.
+- canvas_sdk.v1.data.note.Note: For interacting with Note objects from the Canvas SDK.
+
+```python
+from uuid import UUID
+from http import HTTPStatus
+
+from canvas_sdk.effects.simple_api import JSONResponse
+from canvas_sdk.v1.data.note import Note
+
+
+def is_valid_uuid(possible_uuid):
+    try:
+        uuid_obj = UUID(possible_uuid, version=4)
+    except ValueError:
+        return False
+    return str(uuid_obj) == possible_uuid
+
+
+def note_not_found_response():
+    return JSONResponse(
+        {"error": "Note not found."},
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+
+
+def get_note_from_path_params(path_params) -> Note | None:
+    note_id = path_params["id"]
+    # Ensure the note id is a valid UUID
+    if not is_valid_uuid(note_id):
+        return None
+
+    try:
+        note = Note.objects.get(id=note_id)
+    except (Note.DoesNotExist):
+        return None
+    return note
+```
+
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/examples/example_patient_portal_page.md
+++ b/collections/_sdk/examples/example_patient_portal_page.md
@@ -1,0 +1,220 @@
+---
+title: 'Example Patient Portal Page'
+slug: 'example-example_patient_portal_page'
+---
+
+{% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/example_patient_portal_page' target='_blank'>View the source</a> for this plugin on GitHub." %}
+
+This plugin demonstrates how to embed custom patient facing content and tools to the Canvas patient portal. It provides an example of how to expose new patient-facing content or features via the portal, such as educational materials, forms, or interactive tools. On open, the plugin can launch an application and return effects to update the portal UI or patient data as needed.
+
+## CANVAS_MANIFEST.json
+
+```json
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "example_patient_portal_page",
+    "description": "Edit the description in CANVAS_MANIFEST.json",
+    "url_permissions": [
+        {
+            "url": "https://www.canvasmedical.com/extensions",
+            "permissions": ["ALLOW_SAME_ORIGIN", "SCRIPTS", "MICROPHONE", "CAMERA"]
+        }
+    ],
+    "components": {
+        "applications": [
+            {
+                "class": "example_patient_portal_page.applications.my_application:MyApplication",
+                "name": "My Cool Tool",
+                "description": "Defines the menu item and what it should launch.",
+                "scope": "portal_menu_item",
+                "icon": "assets/icon.png"
+            }
+        ],
+        "protocols": [
+            {
+                "class": "example_patient_portal_page.handlers.my_web_app:MyWebApp",
+                "description": "Serves the application",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": [],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}
+```
+
+## handlers/
+
+### my_web_app.py
+
+This file defines a simple web application, MyWebApp, that serves HTML, JavaScript, and CSS content.
+
+**Authentication**
+
+The app uses session credentials to check if a user is logged in before providing access to its endpoints. This is done in the authenticate method, which returns True only if a logged-in user exists.
+
+**Endpoints**
+
+- **/app/patient-portal-application**:  
+  - Retrieves the current logged-in Patient using an ID supplied in the request headers.
+  - Renders an HTML template ("static/index.html") and supplies the patient's first and last name as context variables.
+  - Returns a rendered HTML page as the response.
+
+- **/app/main.js**:  
+  - Serves the contents of "static/main.js" as JavaScript.
+
+- **/app/styles.css**:  
+  - Serves the contents of "static/styles.css" as CSS.
+
+**Template Rendering**
+
+All files (HTML, JS, CSS) are rendered using the Canvas SDK's render_to_string function, allowing the inclusion of dynamic server-side data, especially for the HTML response.
+
+**Security**
+
+Only authenticated (logged-in) users can access any endpoint. The app enforces this globally by overriding the authenticate method.
+
+
+```python
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import HTMLResponse, Response
+from canvas_sdk.handlers.simple_api import SessionCredentials, SimpleAPI, api
+from canvas_sdk.templates import render_to_string
+from canvas_sdk.v1.data.patient import Patient
+
+#
+# Check out https://docs.canvasmedical.com/sdk/handlers-simple-api-http
+
+
+class MyWebApp(SimpleAPI):
+    PREFIX = "/app"
+
+    # Using session credentials allows us to ensure only logged in users can
+    # access this.
+    def authenticate(self, credentials: SessionCredentials) -> bool:
+        return credentials.logged_in_user != None
+
+    # Serve templated HTML
+    @api.get("/patient-portal-application")
+    def index(self) -> list[Response | Effect]:
+        logged_in_user = Patient.objects.get(id=self.request.headers["canvas-logged-in-user-id"])
+
+        context = {
+            "first_name": logged_in_user.first_name,
+            "last_name": logged_in_user.last_name,
+        }
+
+        return [
+            HTMLResponse(
+                render_to_string("static/index.html", context),
+                status_code=HTTPStatus.OK,
+            )
+        ]
+
+    # Serve the contents of a js file
+    @api.get("/main.js")
+    def get_main_js(self) -> list[Response | Effect]:
+        return [
+            Response(
+                render_to_string("static/main.js").encode(),
+                status_code=HTTPStatus.OK,
+                content_type="text/javascript",
+            )
+        ]
+
+    # Serve the contents of a css file
+    @api.get("/styles.css")
+    def get_css(self) -> list[Response | Effect]:
+        return [
+            Response(
+                render_to_string("static/styles.css").encode(),
+                status_code=HTTPStatus.OK,
+                content_type="text/css",
+            )
+        ]
+```
+
+## assets/
+
+### icon.png
+
+This icon is displayed in the portal menu.
+
+## applications/
+
+### my_application.py
+
+The code defines a custom application called `MyApplication`, which is the mechanism for registering the application in the portal menu..
+
+**Key Functionality**
+
+- The core implementation is within the `on_open` method, which handles the application's "open" event.
+- When the application is opened, it triggers a launch effect (`LaunchModalEffect`) that opens an iframe modal.
+- The iframe modal displays the content found at the URL `/plugin-io/api/example_patient_portal_page/app/patient-portal-application`.
+- The effect specifically targets the main page area (`target=LaunchModalEffect.TargetType.PAGE`) for embedding.
+- The `on_open` method is a customization point where additional logic could be inserted—for example, dynamic URL selection based on application state or data.
+
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.launch_modal import LaunchModalEffect
+from canvas_sdk.handlers.application import Application
+
+
+class MyApplication(Application):
+    """An embeddable application that can be registered to Canvas."""
+
+    def on_open(self) -> Effect:
+        """Handle the on_open event."""
+        # Implement this method to handle the application on_open event.
+        # You can look up data here to be used in knowing what to launch, if
+        # what you're launching depends on some dynamic criteria.
+
+        return LaunchModalEffect(
+            # This URL is what will get iframed. It can be hosted elsewhere,
+            # or it could be hosted by your plugin! Canvas plugins can serve
+            # html, css, js, or json.
+            #
+            # If embedding a remote URL, be sure to declare it in the URL
+            # permissions section of your plugin's CANVAS_MANIFEST.json
+            url="/plugin-io/api/example_patient_portal_page/app/patient-portal-application",
+            target=LaunchModalEffect.TargetType.PAGE,
+        ).apply()
+```
+
+### \__init__.py
+
+This file is empty.
+
+## static/
+
+### main.js
+
+Static javascript referenced by the html template.
+
+### styles.css
+
+Stylesheets referenced by the html template.
+
+### index.html
+
+Templated HTML to render when the menu item is clicked.
+
+<br/>
+<br/>
+<br/>

--- a/scripts/sdk/generate_example_plugins_docs.rb
+++ b/scripts/sdk/generate_example_plugins_docs.rb
@@ -26,10 +26,14 @@ puts
 
 # Define a method to get an external consultation on what a file's purpose is
 def get_llm_explanation_of_python_code(python_file)
+  raise "You must set OPENAI_API_KEY" if OPENAI_API_KEY.nil?
+
   filename = python_file.basename.to_s
   file_content = python_file.readlines.join
 
-  raise "You must set OPENAI_API_KEY" if OPENAI_API_KEY.nil?
+  if file_content.strip.empty?
+    return nil
+  end
 
   uri = URI('https://api.openai.com/v1/responses')
 
@@ -134,7 +138,12 @@ ALERTHTML
           # If it's a python file, ensure the syntax highlighting is set to
           # python when dumping the contents
           elsif child_path.extname == ".py"
-            file.puts(get_llm_explanation_of_python_code(child_path))
+            llm_explanation = get_llm_explanation_of_python_code(child_path)
+            if llm_explanation.nil?
+              file.puts("This file is empty.")
+              next
+            end
+            file.puts(llm_explanation)
             file.puts()
             file.puts("```python")
             child_path.readlines.each do |line|

--- a/test-code-blocks.py
+++ b/test-code-blocks.py
@@ -191,6 +191,13 @@ def main():
         if "node_modules" in markdown_file:
             continue
 
+        # Choosing to skip generated example plugin documentation.
+        # These docs include whole files directly from the plugin, which may
+        # reference other files within that plugin package. Those imports will
+        # not resolve.
+        if "collections/_sdk/examples/" in markdown_file:
+            continue
+
         content = Path(markdown_file).read_text()
         code_blocks = extract_code_blocks(content)
 


### PR DESCRIPTION
This fixes an issue where empty python files caused the docs generator to choke.

It also creates the menu structure for navigating to these generated pages (though newly generated pages need to be added to the menu manually).

As part of adding the menu, I also added 3 initial pages. These were AI generated and lightly edited. I imagine there is much to improve on, but this is more about setting the pattern and creating the space for these pages.

After this is merged, the generation will still need to be manually invoked from this page: https://github.com/canvas-medical/documentation/actions/workflows/generate-example-plugin-docs.yml
Successfully running this action will result in a PR opened with a **starting point** for a guide. Validating and editing this page is a MUST. Do not merge these generated AI pages as-is. Even if accurate, they are often poorly written.