### PR TITLE
Generate Example Plugin Docs `patient_portal_plugin`

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -562,14 +562,20 @@ example_plugins:
     url: /sdk/example-api_samples/
   - title: "Charting API Examples"
     url: /sdk/example-charting_api_examples/
-  - title: "Customize Patient Portal Page"
-    url: /sdk/example-customize_patient_portal_page/
   - title: "Patient Creation Platform Sync"
     url: /sdk/example-patient_creation_platform_sync/
   - title: "Upsert Patient Metadata"
     url: /sdk/example-upsert_patient_metadata/
   - title: "Vitals Visualizer"
     url: /sdk/example-vitals_visualizer_plugin/
+  - title: "Patient Portal Customization"
+    identifier: portal_customization
+
+portal_customization:
+  - title: "Launch an Application"
+    url: /sdk/example-portal-customization-launch_application/
+  - title: "Customize with Widgets"
+    url: /sdk/example-portal-customization-widgets/
 
 sdk_handlers:
   - title: "Action Buttons"

--- a/collections/_sdk/examples/example_patient_portal_page.md
+++ b/collections/_sdk/examples/example_patient_portal_page.md
@@ -1,6 +1,6 @@
 ---
-title: 'Customize Patient Portal Page'
-slug: 'example-customize_patient_portal_page'
+title: 'Launch an Application from Patient Portal'
+slug: 'example-portal-customization-launch_application'
 ---
 
 {% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/example_patient_portal_page' target='_blank'>View the source</a> for this plugin on GitHub." %}

--- a/collections/_sdk/examples/example_patient_portal_page.md
+++ b/collections/_sdk/examples/example_patient_portal_page.md
@@ -5,7 +5,7 @@ slug: 'example-portal-customization-launch_application'
 
 {% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/example_patient_portal_page' target='_blank'>View the source</a> for this plugin on GitHub." %}
 
-This plugin demonstrates how to embed custom patient facing content and tools to the Canvas patient portal. It provides an example of how to expose new patient-facing content or features via the portal, such as educational materials, forms, or interactive tools. On open, the plugin can launch an application and return effects to update the portal UI or patient data as needed.
+This plugin demonstrates how to embed custom patient facing content and tools to the Canvas patient portal. It provides an example of how to expose new patient-facing content or features, such as educational materials, forms, or interactive tools. On open, the plugin can launch an application and return effects to update the portal UI or patient data as needed.
 
 ## CANVAS_MANIFEST.json
 

--- a/collections/_sdk/examples/patient_portal_plugin.md
+++ b/collections/_sdk/examples/patient_portal_plugin.md
@@ -1,16 +1,13 @@
 ---
-title: 'patient_portal_plugin'
-slug: 'example-patient_portal_plugin'
+title: 'Patient Portal Widgets'
+slug: 'example-patient_portal_widgets_plugin'
 ---
 
 {% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/patient_portal_plugin' target='_blank'>View the source</a> for this plugin on GitHub." %}
 
-patient_portal_portal_plugin
-============================
-
 ## Description
 
-The Patient Portal Plugin is a simple plugin that provides various widgets for the patient portal.
+The Patient Portal Widgets Plugin provides various widgets for the patient portal.
 The plugin listens to the `PATIENT_PORTAL__WIDGET_CONFIGURATION` event.
 
 
@@ -50,11 +47,6 @@ In order to deal with `SECRETS` take a look at the
 [SDK documentation](https://docs.canvasmedical.com/sdk/secrets/).
 
 
-## Important Note!
-
-The CANVAS_MANIFEST.json is used when installing your plugin. Please ensure it
-gets updated if you add, remove, or rename protocols.
-
 ## CANVAS_MANIFEST.json
 
 ```json
@@ -67,12 +59,7 @@ gets updated if you add, remove, or rename protocols.
         "protocols": [
             {
                 "class": "patient_portal_plugin.handlers.patient_portal_handler:PatientPortalHandler",
-                "description": "The handler that listens for the patient portal `PATIENT_PORTAL__WIDGET_CONFIGURATION` and responds with the patient portal widgets",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "The handler that listens for the patient portal `PATIENT_PORTAL__WIDGET_CONFIGURATION` and responds with the patient portal widgets"
             }
         ],
         "commands": [],
@@ -258,7 +245,7 @@ class PatientPortalHandler(BaseHandler):
         return self.secrets.get("EMERGENCY_CONTACT") or self.DEFAULT_EMERGENCY_CONTACT
 ```
 
-### __init__.py
+### \___init__.py
 
 This file is empty.
 <br/>

--- a/collections/_sdk/examples/patient_portal_plugin.md
+++ b/collections/_sdk/examples/patient_portal_plugin.md
@@ -1,6 +1,6 @@
 ---
-title: 'Patient Portal Widgets'
-slug: 'example-patient_portal_widgets_plugin'
+title: 'Customize Patient Portal with Widgets'
+slug: 'example-portal-customization-widgets'
 ---
 
 {% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/patient_portal_plugin' target='_blank'>View the source</a> for this plugin on GitHub." %}

--- a/collections/_sdk/examples/patient_portal_plugin.md
+++ b/collections/_sdk/examples/patient_portal_plugin.md
@@ -1,0 +1,266 @@
+---
+title: 'patient_portal_plugin'
+slug: 'example-patient_portal_plugin'
+---
+
+{% include alert.html type="github" content="<a href='https://github.com/canvas-medical/canvas-plugins/tree/main/example-plugins/patient_portal_plugin' target='_blank'>View the source</a> for this plugin on GitHub." %}
+
+patient_portal_portal_plugin
+============================
+
+## Description
+
+The Patient Portal Plugin is a simple plugin that provides various widgets for the patient portal.
+The plugin listens to the `PATIENT_PORTAL__WIDGET_CONFIGURATION` event.
+
+
+## Widgets
+
+### Header Widget
+
+The Header Widget displays the patient's preferred name and has quick links for messaging and scheduling.
+
+For more, visit the [Canvas SDK documentation](https://docs.canvasmedical.com/sdk/data-patient/)
+
+
+### Care Team Widget
+
+It is used to display a compact widget in the Patient Portal that lists the
+active care team members for a patient.
+
+It renders a scrollable list in a compact plugin format of all active members. 
+
+For more information, visit the [Canvas SDK documentation](https://docs.canvasmedical.com/sdk/data-care-team/).
+
+
+### Footer Widget
+
+The Footer Widget displays the support contact information for the patient.
+
+
+## Secrets
+
+The Patient Portal Plugin uses the following secrets:
+
+- `BACKGROUND_COLOR`: The background color for the widgets. Defaults to `#17634d`.
+- `EMERGENCY_CONTACT`: The emergency contact information. Defaults to `1-888-555-5555`.
+
+
+In order to deal with `SECRETS` take a look at the
+[SDK documentation](https://docs.canvasmedical.com/sdk/secrets/).
+
+
+## Important Note!
+
+The CANVAS_MANIFEST.json is used when installing your plugin. Please ensure it
+gets updated if you add, remove, or rename protocols.
+
+## CANVAS_MANIFEST.json
+
+```json
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "patient_portal_plugin",
+    "description": "Patient Portal Plugin for Canvas",
+    "components": {
+        "protocols": [
+            {
+                "class": "patient_portal_plugin.handlers.patient_portal_handler:PatientPortalHandler",
+                "description": "The handler that listens for the patient portal `PATIENT_PORTAL__WIDGET_CONFIGURATION` and responds with the patient portal widgets",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": [
+        "BACKGROUND_COLOR",
+        "EMERGENCY_CONTACT"
+    ],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}
+```
+
+## templates/
+
+### care_team_widget.html
+
+### header_widget.html
+
+### footer_widget.html
+
+## handlers/
+
+### patient_portal_handler.py
+
+**Purpose**
+
+The code defines a handler, PatientPortalHandler, for the Canvas Medical SDK that renders custom widgets on the patient portal within Canvas. It listens for a specific widget configuration event and responds by displaying a set of widgets (header, care team, and footer) with certain configurable properties.
+
+**Event Handling**
+
+The handler is triggered (via RESPONDS_TO) when the event type PATIENT_PORTAL__WIDGET_CONFIGURATION occurs. When Canvas requests portal widget configuration for a patient, this handler gets called.
+
+**Widgets Produced**
+
+- **Header Widget**:  
+  Collects basic patient information (first name, last name, etc.), constructs a "preferred full name," and passes it to an HTML template along with a configurable background color (using either a secret or a default).
+- **Care Team Widget**:  
+  Fetches the patient's active care team members. For each member, gathers name components, professional role, profile photo URL, and composes formatted display strings. This list is rendered in a compact widget, styled with the background color as a title color.
+- **Footer Widget**:  
+  Renders a footer using a background color and an emergency contact number, both customizable via secrets, falling back to sensible defaults if not specified.
+
+**Widget Rendering**
+
+For each widget, an appropriate HTML template is rendered with the relevant payload/context, and the widget is then wrapped as a PortalWidget with defined size and priority. These effects are returned as a list which the Canvas platform uses to display each widget on the patient portal.
+
+**Customization and Defaults**
+
+Two elements are customizable via the plugin’s secrets dictionary:
+- BACKGROUND_COLOR: Sets the color for visual elements (widgets, titles).
+- EMERGENCY_CONTACT: Sets the emergency contact number in the footer.
+
+If these are not provided, default values are used:
+- DEFAULT_BACKGROUND_COLOR = "#17634d"
+- DEFAULT_EMERGENCY_CONTACT = "1-888-555-5555"
+
+**Summary**
+
+This file enables a Canvas plugin to inject and style custom patient-facing widgets: a personalized header, a care team overview, and an emergency contact panel, all triggered when the platform requests configuration for the patient portal widgets. It leverages data models and template rendering of the Canvas SDK, with runtime customization via plugin secrets.
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.widgets import PortalWidget
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers.base import BaseHandler
+from canvas_sdk.templates import render_to_string
+from canvas_sdk.v1.data import Patient
+from canvas_sdk.v1.data.care_team import CareTeamMembership, CareTeamMembershipStatus
+
+
+# Inherit from BaseHandler to properly get registered for events
+class PatientPortalHandler(BaseHandler):
+    """Handler responsible for rendering a patient portal widgets."""
+
+    RESPONDS_TO = EventType.Name(EventType.PATIENT_PORTAL__WIDGET_CONFIGURATION)
+
+    # Default background and title color for the portal's widgets if not provided in secrets
+    DEFAULT_BACKGROUND_COLOR = "#17634d"
+
+    # Default emergency contact number if not provided in secrets
+    DEFAULT_EMERGENCY_CONTACT = "1-888-555-5555"
+
+    def compute(self) -> list[Effect]:
+        """This method gets called when an event of the type RESPONDS_TO is fired."""
+        return [
+            self.header_widget,
+            self.care_team_widget,
+            self.footer_widget,
+        ]
+
+    @property
+    def header_widget(self) -> Effect:
+        """Constructs the header widget for the patient portal."""
+        # Get the patient needed fields to generate the preferred full name
+        patient = Patient.objects.only("first_name", "last_name", "suffix", "nickname").get(id=self.target)
+
+        payload = {
+            "preferred_full_name": patient.preferred_full_name,
+            "background_color": self.background_color,
+        }
+
+        header_widget = PortalWidget(
+            content=render_to_string("templates/header_widget.html", payload),
+            size=PortalWidget.Size.EXPANDED,
+            priority=10,
+        )
+
+        return header_widget.apply()
+
+    @property
+    def care_team_widget(self) -> Effect:
+        """Constructs the care team widget for the patient portal."""
+        patient_care_team = CareTeamMembership.objects.values(
+            "staff__first_name",
+            "staff__last_name",
+            "staff__prefix",
+            "staff__suffix",
+            "staff__photos__url",
+            "role_display",
+        ).filter(
+            patient__id=self.target,
+            status=CareTeamMembershipStatus.ACTIVE,
+        )
+
+        care_team = []
+        for member in patient_care_team:
+            # Aliasing the member's name components for clarity
+            name = f"{member['staff__first_name']} {member['staff__last_name']}"
+            prefixed_name = f"{member['staff__prefix']} " if member['staff__prefix'] else name
+            professional_name = f"{prefixed_name}, {member['staff__suffix']}" if member['staff__suffix'] else prefixed_name
+            photo_url = member['staff__photos__url']
+            role = member['role_display']
+
+            care_team.append(
+                {
+                    "name": name,
+                    "prefixed_name": prefixed_name,
+                    "professional_name": professional_name,
+                    "photo_url": photo_url,
+                    "role": role,
+                }
+            )
+
+        payload = {
+            "care_team": care_team,
+            "title_color": self.background_color,
+        }
+
+        care_team_widget = PortalWidget(
+            content=render_to_string("templates/care_team_widget.html", payload),
+            size=PortalWidget.Size.COMPACT,
+            priority=11,
+        )
+
+        return care_team_widget.apply()
+
+    @property
+    def footer_widget(self) -> Effect:
+        """This method gets called when an event of the type RESPONDS_TO is fired."""
+        return PortalWidget(
+            content=render_to_string("templates/footer_widget.html", {
+                "background_color": self.background_color,
+                "emergency_contact": self.emergency_contact,
+            }),
+            size=PortalWidget.Size.EXPANDED,
+            priority=12,
+        ).apply()
+
+    @property
+    def background_color(self) -> str:
+        """Get the background color from secrets, defaulting to a specific color if not set."""
+        return self.secrets.get("BACKGROUND_COLOR") or self.DEFAULT_BACKGROUND_COLOR
+
+    @property
+    def emergency_contact(self) -> str:
+        """Get the emergency contact from secrets, defaulting to a specific contact if not set."""
+        return self.secrets.get("EMERGENCY_CONTACT") or self.DEFAULT_EMERGENCY_CONTACT
+```
+
+### __init__.py
+
+This file is empty.
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/examples/vitals_visualizer_plugin.md
+++ b/collections/_sdk/examples/vitals_visualizer_plugin.md
@@ -307,9 +307,9 @@ class VitalsVisualizerButton(ActionButton):
         ]
 ```
 
-### __init__.py
+### \___init__.py
 
-The __init__.py file is responsible for including and registering the handlers (API endpoints or other callable objects) that empower the "vitals_visualizer_plugin" to provide its intended functionality within the Canvas Medical application. It ensures that the plugin integrates properly with the Canvas framework by exposing its custom logic via the required handlers.
+This file is blank.
 
 <br/>
 <br/>


### PR DESCRIPTION
## TODO
- [x] Remove redundant header if the plugin's readme also specifies a header
- [x] Review content for accuracy and edit to seem a little less generated. Make sure the content is actually useful and relevant. Remember, this is just a starting point.
- [x] Add an entry to `_data/menus.yml` (This could be automated, but it would resort every list in that file, which is not desireable.)