### PR TITLE
chore: add Python examples for patient data retrieval

### DIFF
--- a/collections/_sdk/data/patient.md
+++ b/collections/_sdk/data/patient.md
@@ -99,7 +99,7 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | settings                 | [PatientSetting](#patientsetting)                                         |
 | subscribed_coverages     | [Coverage](/sdk/data-coverage/#coverage)[]                                |
 | tasks                    | [Task](/sdk/data-task/#task)[]                                            |
-| patient_addresses        | [PatientAddress](#patientaddress)[]                                       |
+| addresses        | [PatientAddress](#patientaddress)[]                                       |
 | telecom                  | [PatientContactPoint](#patientcontactpoint)[]                             |
 | metadata                 | [PatientMetadata](#patientmetadata)[]                                     |
 | user                     | [CanvasUser](/sdk/data-user/)[]                                           |

--- a/collections/_sdk/data/patient.md
+++ b/collections/_sdk/data/patient.md
@@ -126,6 +126,18 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | state       | String                                                  |
 | patient     | [Patient](#patient)                                     |
 
+```python
+from canvas_sdk.v1.data.patient import Patient
+from logger import log
+
+patient_id = "d7af3e356368446c85b40a5d6ff7288e"
+patient = Patient.objects.get(id=patient_id)
+patient_addresses = patient.addresses.all()
+
+for addr in patient_addresses:
+  log.info(f"Patient address: {addr.city}, {addr.state_code}, {addr.postal_code}")
+```
+
 ### PatientContactPoint
 
 | Field Name         | Type                                                                  |
@@ -144,6 +156,18 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | verification_token | String                                                                |
 | opted_out          | Boolean                                                               |
 
+```python
+from canvas_sdk.v1.data.patient import Patient
+from logger import log
+
+patient_id = "d7af3e356368446c85b40a5d6ff7288e"
+patient = Patient.objects.get(id=patient_id)
+patient_contacts = patient.contact_points.all()
+
+for contact in patient_contacts:
+   log.info(f"Patient contact: {contact.contact_point_system.id}")
+```
+
 ### PatientExternalIdentifier
 
 | Field Name      | Type                |
@@ -159,6 +183,18 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | value           | String              |
 | issued_date     | Date                |
 | expiration_date | Date                |
+
+```python
+from canvas_sdk.v1.data.patient import Patient
+from logger import log
+
+patient_id = "d7af3e356368446c85b40a5d6ff7288e"
+patient = Patient.objects.get(id=patient_id)
+patient_external_identifiers = patient.patient_external_identifiers.all()
+
+for identifier in patient_external_identifiers:
+   log.info(f"Patient external identifier: {identifier.system}, {identifier.value}")
+```
 
 ### PatientSetting
 
@@ -179,6 +215,18 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | patient    | [Patient](#patient) |
 | key        | String              |
 | value      | String              |
+
+```python
+from canvas_sdk.v1.data.patient import Patient
+from logger import log
+
+patient_id = "d7af3e356368446c85b40a5d6ff7288e"
+patient = Patient.objects.get(id=patient_id)
+patient_metadata = patient.patient_metadata.all()
+
+for metadata in patient_metadata:
+   log.info(f"Patient metadata: {metadata.key}, {metadata.value}")
+```
 
 ## Enumeration types
 

--- a/collections/_sdk/data/patient.md
+++ b/collections/_sdk/data/patient.md
@@ -76,14 +76,17 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | birth_order              | Integer                                                                   |
 | default_location_id      | Integer                                                                   |
 | default_provider_id      | Integer                                                                   |
+| addresses                | [PatientAddress](#patientaddress)[]                                       |
 | allergy_intolerances     | [AllergyIntolerance](/sdk/data-allergy-intolerance/#allergyintolerance)[] |
-| billing_line_items       | BillingLineItem[]                                                         |
+| billing_line_items       | [BillingLineItem](/sdk/data-billing-line-item/)                           |
+| business_line            | [BusinessLine](/sdk/data-business-line/)                                  |
 | care_team_memberships    | [CareTeamMembership](/sdk/data-care-team/#careteammembership)[]           |
 | conditions               | [Condition](/sdk/data-condition/#condition)[]                             |
 | coverages                | [Coverage](/sdk/data-coverage/#coverage)[]                                |
 | dependent_coverages      | [Coverage](/sdk/data-coverage/#coverage)[]                                |
 | detected_issues          | [DetectedIssue](/sdk/data-detected-issue/#detectedissue)[]                |
 | devices                  | [Device](/sdk/data-device/#device)[]                                      |
+| external_identifiers     | [PatientExternalIdentifier](#patientexternalidentifier)[]                 |
 | imaging_orders           | [ImagingOrder](/sdk/data-imaging/#imagingorder)[]                         |
 | imaging_reports          | [ImagingReport](/sdk/data-imaging/#imagingreport)[]                       |
 | imaging_reviews          | [ImagingReview](/sdk/data-imaging/#imagingreview)[]                       |
@@ -92,18 +95,15 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | lab_reports              | [LabReport](/sdk/data-labs/#labreport)[]                                  |
 | lab_reviews              | [LabReview](/sdk/data-labs/#labreview)[]                                  |
 | medications              | [Medication](/sdk/data-medication/#medication)[]                          |
+| metadata                 | [PatientMetadata](#patientmetadata)[]                                     |
 | observations             | [Observation](/sdk/data-observation/#observation)[]                       |
-| external_identifiers     | [PatientExternalIdentifier](#patientexternalidentifier)[]                 |
 | preferred_pharmacy       | JSON                                                                      |
 | protocol_overrides       | [ProtocolOverride](/sdk/data-protocol-override/#protocoloverride)[]       |
 | settings                 | [PatientSetting](#patientsetting)                                         |
 | subscribed_coverages     | [Coverage](/sdk/data-coverage/#coverage)[]                                |
 | tasks                    | [Task](/sdk/data-task/#task)[]                                            |
-| addresses        | [PatientAddress](#patientaddress)[]                                       |
 | telecom                  | [PatientContactPoint](#patientcontactpoint)[]                             |
-| metadata                 | [PatientMetadata](#patientmetadata)[]                                     |
 | user                     | [CanvasUser](/sdk/data-user/)[]                                           |
-| business_line            | [BusinessLine](/sdk/data-business-line/)                                  |
 
 ### PatientAddress
 
@@ -136,7 +136,7 @@ patient = Patient.objects.get(id=patient_id)
 patient_addresses = patient.addresses.all()
 
 for addr in patient_addresses:
-  log.info(f"Patient address: {addr.city}, {addr.state_code}, {addr.postal_code}")
+  log.info(f"Patient address: {addr.city}, {addr.state_code}, {addr.postal_code}") # Seattle, WA, 98118
 ```
 
 ### PatientContactPoint
@@ -166,7 +166,7 @@ patient = Patient.objects.get(id=patient_id)
 patient_contacts = patient.telecom.all()
 
 for contact in patient_contacts:
-   log.info(f"Patient contact: {contact.contact_point_system.id}")
+   log.info(f"Patient contact: {contact.system} - {contact.value}") # phone - 5555555555
 ```
 
 ### PatientExternalIdentifier
@@ -191,10 +191,10 @@ from logger import log
 
 patient_id = "d7af3e356368446c85b40a5d6ff7288e"
 patient = Patient.objects.get(id=patient_id)
-patient_external_identifiers = patient.patient_external_identifiers.all()
+patient_external_identifiers = patient.external_identifiers.all()
 
 for identifier in patient_external_identifiers:
-   log.info(f"Patient external identifier: {identifier.system}, {identifier.value}")
+   log.info(f"Patient external identifier: {identifier.system}, {identifier.value}")  # https://www.example.com - abc123
 ```
 
 ### PatientSetting
@@ -223,10 +223,10 @@ from logger import log
 
 patient_id = "d7af3e356368446c85b40a5d6ff7288e"
 patient = Patient.objects.get(id=patient_id)
-patient_metadata = patient.patient_metadata.all()
+patient_metadata = patient.metadata.all()
 
 for metadata in patient_metadata:
-   log.info(f"Patient metadata: {metadata.key}, {metadata.value}")
+   log.info(f"Patient metadata: {metadata.key}, {metadata.value}") # favorite_color - red
 ```
 
 ## Enumeration types

--- a/collections/_sdk/data/patient.md
+++ b/collections/_sdk/data/patient.md
@@ -162,7 +162,7 @@ from logger import log
 
 patient_id = "d7af3e356368446c85b40a5d6ff7288e"
 patient = Patient.objects.get(id=patient_id)
-patient_contacts = patient.contact_points.all()
+patient_contacts = patient.telecom.all()
 
 for contact in patient_contacts:
    log.info(f"Patient contact: {contact.contact_point_system.id}")

--- a/collections/_sdk/data/patient.md
+++ b/collections/_sdk/data/patient.md
@@ -99,6 +99,7 @@ patients = Patient.objects.filter(first_name="Bob", last_name="Loblaw", birth_da
 | settings                 | [PatientSetting](#patientsetting)                                         |
 | subscribed_coverages     | [Coverage](/sdk/data-coverage/#coverage)[]                                |
 | tasks                    | [Task](/sdk/data-task/#task)[]                                            |
+| patient_addresses        | [PatientAddress](#patientaddress)[]                                       |
 | telecom                  | [PatientContactPoint](#patientcontactpoint)[]                             |
 | metadata                 | [PatientMetadata](#patientmetadata)[]                                     |
 | user                     | [CanvasUser](/sdk/data-user/)[]                                           |


### PR DESCRIPTION
Added Python code examples for retrieving patient addresses, contact points, external identifiers, and metadata.