### PR TITLE
add note fax effect

### DIFF
--- a/collections/_sdk/effects/note.md
+++ b/collections/_sdk/effects/note.md
@@ -97,15 +97,15 @@ Sends an existing note via fax to a specified recipient. This effect allows you 
 
 #### Attributes
 
-| Attribute               | Type            | Description                                                   | Required |
-|-------------------------|-----------------|---------------------------------------------------------------|----------|
-| `note_id`               | `UUID` or `str` | Identifier of the note to fax                                 | Yes      |
-| `recipient_name`        | `str`           | Name of the fax recipient                                     | Yes      |
-| `recipient_fax_number`  | `str`           | Fax number of the recipient                                   | Yes      |
-| `include_coversheet`    | `bool`          | Whether to include a coversheet with the fax                  | No       |
-| `subject`               | `str` or `None` | Subject line for the coversheet (required if coversheet used) | No       |
+| Attribute               | Type            | Description                                                      | Required |
+|-------------------------|-----------------|------------------------------------------------------------------|----------|
+| `note_id`               | `UUID` or `str` | Identifier of the note to fax                                    | Yes      |
+| `recipient_name`        | `str`           | Name of the fax recipient                                        | Yes      |
+| `recipient_fax_number`  | `str`           | Fax number of the recipient. Should include the country code     | Yes      |
+| `include_coversheet`    | `bool`          | Whether to include a coversheet with the fax                     | No       |
+| `subject`               | `str` or `None` | Subject line for the coversheet (required if coversheet used)    | No       |
 | `comment`               | `str` or `None` | Additional comments for coversheet (required if coversheet used) | No    |
-| `location_id`           | `UUID` or `str` or `None` | Practice location ID (required if coversheet used)  | No       |
+| `location_id`           | `UUID` or `str` or `None` | Practice location ID (required if coversheet used)               | No       |
 
 #### Implementation Details
 
@@ -129,7 +129,7 @@ class Protocol(BaseHandler):
         fax_effect = FaxNoteEffect(
             note_id="existing-note-uuid",
             recipient_name="Dr. Jane Smith",
-            recipient_fax_number="5551234567"
+            recipient_fax_number="15551234567"
         )
 
         return [fax_effect.apply()]
@@ -148,7 +148,7 @@ class Protocol(BaseHandler):
         fax_effect = FaxNoteEffect(
             note_id="existing-note-uuid",
             recipient_name="Dr. Jane Smith",
-            recipient_fax_number="5551234567",
+            recipient_fax_number="15551234567",
             include_coversheet=True,
             subject="Patient Referral - Follow-up Care",
             comment="Please review attached consultation notes for continuing care.",


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-3484

This pull request adds comprehensive documentation for the new `Fax Note` effect in the SDK, enabling users to send patient notes via fax to external healthcare providers or facilities. The documentation covers the required and optional attributes, validation logic, and provides example usage for both basic faxing and faxing with a coversheet.

### New Effect Documentation

* Added a detailed section for the `Fax Note` effect, describing its purpose, required and optional attributes, and validation rules.

### Example Usage

* Included example code snippets for sending a note via fax, both with and without a coversheet, demonstrating how to use the new `FaxNoteEffect` in a `Protocol` class.