### PR TITLE
Add NoteTask documentation to SDK data module

### DIFF
--- a/collections/_sdk/data/task.md
+++ b/collections/_sdk/data/task.md
@@ -58,6 +58,71 @@ task = Task.objects.get(id="7895e1db-f8de-4660-a0a3-9e5b43a475c6")
 # [(<Staff: Sam Jones>, "Please call patient.")]
 ```
 
+### Note Tasks and Initial Comments
+
+A `NoteTask` represents the link between a Task command and the `Task` it generates. When a task is created via a Task command, a `NoteTask` record is created that stores the **initial comment** provided during task creation in the `internal_comment` field.
+
+This is important because `task.comments.all()` only returns manual comments added after the task is created through the interface—it does not include the original comment entered during task creation. To access that initial comment, you need to use the `NoteTask` model.
+
+To get a note task by its identifier:
+
+```python
+from canvas_sdk.v1.data.task import NoteTask
+
+note_task = NoteTask.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+print(f"Initial comment: {note_task.internal_comment}")
+```
+
+From a `Task` object, you can access the associated `NoteTask` to retrieve the initial comment:
+
+```python
+from canvas_sdk.v1.data.task import Task
+
+task = Task.objects.get(id="7895e1db-f8de-4660-a0a3-9e5b43a475c6")
+
+# Access the NoteTask to get the initial comment
+note_task = task.note_tasks.first()
+if note_task:
+    print(f"Initial comment: {note_task.internal_comment}")
+    print(f"Original title: {note_task.original_title}")
+    print(f"Original assignee: {note_task.original_assignee}")
+```
+
+Common workflow pattern: handling a TASK_CREATED event and accessing the initial comment:
+
+```python
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers import BaseHandler
+from canvas_sdk.v1.data.task import Task
+
+class TaskCreatedHandler(BaseHandler):
+    RESPONDS_TO = [EventType.Name(EventType.TASK_CREATED)]
+
+    def compute(self):
+        task_id = self.target.id
+        task = Task.objects.get(id=task_id)
+
+        # Get the initial comment from the NoteTask
+        note_task = task.note_tasks.first()
+        if note_task:
+            initial_comment = note_task.internal_comment
+            # Use the initial comment for your logic
+            self.log(f"Task created with initial comment: {initial_comment}")
+```
+
+From a `Note` object, note tasks can be accessed with the `note_tasks` attribute:
+
+```python
+from canvas_sdk.v1.data.note import Note
+
+note = Note.objects.get(id="1eed3ea2a8d546a1b681a2a45de1d790")
+note_tasks = note.note_tasks.all()
+
+for note_task in note_tasks:
+    print(f"Task: {note_task.original_title}")
+    print(f"Initial comment: {note_task.internal_comment}")
+```
+
 ## Attributes
 
 ### Task
@@ -80,6 +145,30 @@ task = Task.objects.get(id="7895e1db-f8de-4660-a0a3-9e5b43a475c6")
 | comments   | [TaskComment](#taskcomment)[]         |
 | labels     | [TaskLabel](#tasklabel)[]             |
 | metadata   | [TaskMetadata](#taskmetadata)[]       |
+| note_tasks | [NoteTask](#notetask)[]               |
+
+### NoteTask
+
+| Field Name        | Type                                    |
+| ----------------- | --------------------------------------- |
+| id                | UUID                                    |
+| dbid              | Integer                                 |
+| created           | DateTime                                |
+| modified          | DateTime                                |
+| originator        | [CanvasUser](/sdk/data-canvas-user/)    |
+| committer         | [CanvasUser](/sdk/data-canvas-user/)    |
+| entered_in_error  | [CanvasUser](/sdk/data-canvas-user/)    |
+| deleted           | Boolean                                 |
+| note              | [Note](/sdk/data-note/#note)            |
+| task              | [Task](#task)                           |
+| patient           | [Patient](/sdk/data-patient/#patient)   |
+| original_title    | String                                  |
+| original_assignee | [Staff](/sdk/data-staff/#staff)         |
+| original_team     | [Team](/sdk/data-team/)                 |
+| original_role     | [CareTeamRole](/sdk/data-care-team/#careteamrole) |
+| original_due      | DateTime                                |
+| internal_comment  | String                                  |
+| labels            | [TaskLabel](#tasklabel)[]               |
 
 ### TaskComment
 


### PR DESCRIPTION
Linked Issue:
https://canvasmedical.atlassian.net/browse/KOALA-3397

Linked PRs:
https://github.com/canvas-medical/canvas-plugins/pull/1270
https://github.com/canvas-medical/canvas/pull/18368

Added comprehensive documentation for the NoteTask model, which links Task commands to the Tasks they generate and provides access to the initial comment (internal_comment) provided during task creation.

Key additions:
- New "Note Tasks and Initial Comments" section with usage examples
- NoteTask attributes table with all fields
- Updated Task attributes to include note_tasks relationship
- Example workflow for handling TASK_CREATED events

Resolves: canvas-medical/canvas-plugins#557

🤖 Generated with [Claude Code](https://claude.com/claude-code)