### PR TITLE
add missing fields to CanvasUser documentation

### DIFF
--- a/collections/_sdk/data/canvas-user.md
+++ b/collections/_sdk/data/canvas-user.md
@@ -41,12 +41,14 @@ users = CanvasUser.objects.filter(phone_number="1111111111", email="test@canvasm
 
 ### User
 
-| Field Name               | Type                                                                      |
-|--------------------------|---------------------------------------------------------------------------|
-| dbid                     | Integer                                                                   |
-| email                    | String                                                                    |
-| phone_number             | String                                                                    |
-| last_invite_date_time    | DateTime                                                                  |
+| Field Name            | Type     |
+| --------------------- | -------- |
+| dbid                  | Integer  |
+| email                 | String   |
+| phone_number          | String   |
+| is_staff              | Boolean  |
+| is_portal_registered  | Boolean  |
+| last_invite_date_time | DateTime |
 
 <br/>
 <br/>


### PR DESCRIPTION
`is_portal_registered` and `is_staff` fields were missing from the documentation for CanvasUser