### PR TITLE
KOALA-3886: Add IntegrationTask, Imaging, Lab & Specialty ReportTemplates in Canvas_SDK

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -850,12 +850,18 @@ data_module:
   - title: "Immunization"
     url: /sdk/data-immunization/
     description: A record of a vaccination that is being administered to a patient, either now, in the past, or in the future.
+  - title: "IntegrationTask"
+    url: /sdk/data-integration-task/
+    description: Incoming documents that need processing, including faxes, document uploads, and patient portal submissions.
   - title: "Labs"
     url: /sdk/data-labs/
     description: Analysis of clinical specimens to obtain information about the health of a patient.
   - title: "LabPartner"
     url: /sdk/data-lab-partner-and-test/
     description: Lab partners and the tests they offer within Canvas.
+  - title: "LabReportTemplate"
+    url: /sdk/data-lab-report-template/
+    description: Templates for Point of Care (POC) labs and custom lab reports.
   - title: "Medication"
     url: /sdk/data-medication/
     description: A record of a medication that is being consumed by a patient, either now, in the past, or in the future.
@@ -913,6 +919,9 @@ data_module:
   - title: "ServiceProvider"
     url: /sdk/data-serviceprovider/
     description: Data associated with Service Providers.
+  - title: "SpecialtyReportTemplate"
+    url: /sdk/data-specialty-report-template/
+    description: Templates for LLM-powered specialty and referral report parsing.
   - title: "Staff"
     url: /sdk/data-staff
     description: Data associated with Staff members.

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -921,7 +921,7 @@ data_module:
     description: Data associated with Service Providers.
   - title: "SpecialtyReportTemplate"
     url: /sdk/data-specialty-report-template/
-    description: Templates for LLM-powered specialty and referral report parsing.
+    description: Templates for specialty and referral reports.
   - title: "Staff"
     url: /sdk/data-staff
     description: Data associated with Staff members.

--- a/collections/_sdk/data/imaging.md
+++ b/collections/_sdk/data/imaging.md
@@ -183,7 +183,6 @@ tasks = imaging_order.get_task_objects().all()
 
 | Field Name      | Type                                                                  |
 |-----------------|-----------------------------------------------------------------------|
-| id              | UUID                                                                  |
 | dbid            | Integer                                                               |
 | report_template | [ImagingReportTemplate](#imagingreporttemplate)                       |
 | sequence        | Integer                                                               |
@@ -199,7 +198,6 @@ tasks = imaging_order.get_task_objects().all()
 
 | Field Name | Type                                                    |
 |------------|---------------------------------------------------------|
-| id         | UUID                                                    |
 | dbid       | Integer                                                 |
 | field      | [ImagingReportTemplateField](#imagingreporttemplatefield) |
 | label      | String                                                  |

--- a/collections/_sdk/data/imaging.md
+++ b/collections/_sdk/data/imaging.md
@@ -7,7 +7,7 @@ hidden: false
 
 ## Introduction
 
-The `ImagingOrder`, `ImagingReview` and `ImagingReport` models represent imaging results.
+The `ImagingOrder`, `ImagingReview` and `ImagingReport` models represent imaging results. The `ImagingReportTemplate`, `ImagingReportTemplateField`, and `ImagingReportTemplateFieldOption` models represent templates for structured imaging report data capture.
 
 ## Basic Usage
 
@@ -32,6 +32,30 @@ reviews = patient.imaging_reviews.all()
 reports = patient.imaging_results.all()
 ```
 
+### Imaging Report Templates
+
+To retrieve an `ImagingReportTemplate` by identifier:
+
+```python
+from canvas_sdk.v1.data.imaging import ImagingReportTemplate
+
+template = ImagingReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+```
+
+To access a template's fields and field options:
+
+```python
+from canvas_sdk.v1.data.imaging import ImagingReportTemplate
+
+template = ImagingReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+for field in template.fields.all():
+    print(f"Field: {field.label}, Type: {field.type}, Required: {field.required}")
+
+    for option in field.options.all():
+        print(f"  Option: {option.label} ({option.key})")
+```
+
 ## Filtering
 
 Imaging orders, reviews, and reports can be filtered by any attribute that exists on the models.
@@ -48,6 +72,20 @@ from canvas_sdk.v1.data.imaging import ImagingOrder, ImagingReview, ImagingRepor
 orders = ImagingOrder.objects.filter(status="completed")
 reviews = ImagingReview.objects.filter(is_released_to_patient=False)
 reports = ImagingReport.objects.filter(requires_signature=True)
+```
+
+### Filtering Imaging Report Templates
+
+The `ImagingReportTemplate` model provides convenient filter methods for common use cases:
+
+```python
+from canvas_sdk.v1.data.imaging import ImagingReportTemplate
+
+active_templates = ImagingReportTemplate.objects.active()
+matching_templates = ImagingReportTemplate.objects.search("chest x-ray")
+custom_templates = ImagingReportTemplate.objects.custom()
+builtin_templates = ImagingReportTemplate.objects.builtin()
+results = ImagingReportTemplate.objects.active().custom().search("mri")
 ```
 
 ## Related Tasks
@@ -124,6 +162,48 @@ tasks = imaging_order.get_task_objects().all()
 | result_date        | Date                                                                  |
 | original_date      | Date                                                                  |
 | review             | [ImagingReview](#imagingreview)                                       |
+
+### ImagingReportTemplate
+
+| Field Name      | Type                                                      |
+|-----------------|-----------------------------------------------------------|
+| id              | UUID                                                      |
+| dbid            | Integer                                                   |
+| name            | String                                                    |
+| long_name       | String                                                    |
+| code            | String                                                    |
+| code_system     | String                                                    |
+| search_keywords | String                                                    |
+| active          | Boolean                                                   |
+| custom          | Boolean                                                   |
+| rank            | Integer                                                   |
+| fields          | [ImagingReportTemplateField](#imagingreporttemplatefield)[] |
+
+### ImagingReportTemplateField
+
+| Field Name      | Type                                                                  |
+|-----------------|-----------------------------------------------------------------------|
+| id              | UUID                                                                  |
+| dbid            | Integer                                                               |
+| report_template | [ImagingReportTemplate](#imagingreporttemplate)                       |
+| sequence        | Integer                                                               |
+| code            | String                                                                |
+| code_system     | String                                                                |
+| label           | String                                                                |
+| units           | String                                                                |
+| type            | String                                                                |
+| required        | Boolean                                                               |
+| options         | [ImagingReportTemplateFieldOption](#imagingreporttemplatefieldoption)[] |
+
+### ImagingReportTemplateFieldOption
+
+| Field Name | Type                                                    |
+|------------|---------------------------------------------------------|
+| id         | UUID                                                    |
+| dbid       | Integer                                                 |
+| field      | [ImagingReportTemplateField](#imagingreporttemplatefield) |
+| label      | String                                                  |
+| key        | String                                                  |
 
 ## Enumeration types
 

--- a/collections/_sdk/data/integration_task.md
+++ b/collections/_sdk/data/integration_task.md
@@ -100,7 +100,7 @@ team_reviews = IntegrationTaskReview.objects.by_team("team-uuid-here")
 | title            | String                                                |
 | channel          | [IntegrationTaskChannel](#integrationtaskchannel)     |
 | patient          | [Patient](/sdk/data-patient/#patient)                 |
-| service_provider | [ServiceProvider](/sdk/data-service-provider)         |
+| service_provider | [ServiceProvider](/sdk/data-serviceprovider/#service-provider) |
 | reviews          | [IntegrationTaskReview](#integrationtaskreview)[]     |
 
 #### Properties

--- a/collections/_sdk/data/integration_task.md
+++ b/collections/_sdk/data/integration_task.md
@@ -1,0 +1,162 @@
+---
+title: "IntegrationTask"
+slug: "data-integration-task"
+excerpt: "Canvas SDK IntegrationTask"
+hidden: false
+---
+
+## Introduction
+
+The `IntegrationTask` and `IntegrationTaskReview` models represent incoming documents that need processing and their associated review assignments. Integration tasks include faxes, document uploads, lab results, and patient portal submissions.
+
+## Basic Usage
+
+To get an integration task by its identifier, use the `get` method on the `IntegrationTask` model manager:
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTask
+
+task = IntegrationTask.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
+```
+
+To get an integration task review:
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTaskReview
+
+review = IntegrationTaskReview.objects.get(id="c1a5a35a-4ee2-4a0e-85c0-21739dc8c4a8")
+```
+
+From a `Patient` object, integration tasks for the patient can be accessed with the `integration_tasks` attribute:
+
+```python
+from canvas_sdk.v1.data.patient import Patient
+
+patient = Patient.objects.get(id="36950971cb3e4174ad8b9d365abfd6d0")
+tasks_for_patient = patient.integration_tasks.all()
+```
+
+## Filtering
+
+Integration tasks and reviews can be filtered by any attribute that exists on the models. The models also provide convenient filter methods for common use cases.
+
+### By Status
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTask
+
+unread_tasks = IntegrationTask.objects.unread()
+pending_tasks = IntegrationTask.objects.pending_review()
+processed_tasks = IntegrationTask.objects.processed()
+error_tasks = IntegrationTask.objects.with_errors()
+junked_tasks = IntegrationTask.objects.junked()
+active_tasks = IntegrationTask.objects.not_junked()
+```
+
+### By Channel
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTask
+
+faxes = IntegrationTask.objects.faxes()
+uploads = IntegrationTask.objects.uploads()
+from_engine = IntegrationTask.objects.from_integration_engine()
+from_portal = IntegrationTask.objects.from_patient_portal()
+```
+
+### By Patient
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTask
+
+patient_tasks = IntegrationTask.objects.for_patient("36950971cb3e4174ad8b9d365abfd6d0")
+unread_faxes = IntegrationTask.objects.for_patient("36950971cb3e4174ad8b9d365abfd6d0").faxes().unread()
+```
+
+### Filtering Reviews
+
+```python
+from canvas_sdk.v1.data.integration_task import IntegrationTaskReview
+
+task_reviews = IntegrationTaskReview.objects.for_task("d2194110-5c9a-4842-8733-ef09ea5ead11")
+active_reviews = IntegrationTaskReview.objects.active()
+junked_reviews = IntegrationTaskReview.objects.junked()
+reviewer_reviews = IntegrationTaskReview.objects.by_reviewer("staff-uuid-here")
+team_reviews = IntegrationTaskReview.objects.by_team("team-uuid-here")
+```
+
+## Attributes
+
+### IntegrationTask
+
+| Field Name       | Type                                                  |
+|------------------|-------------------------------------------------------|
+| id               | UUID                                                  |
+| dbid             | Integer                                               |
+| created          | DateTime                                              |
+| modified         | DateTime                                              |
+| status           | [IntegrationTaskStatus](#integrationtaskstatus)       |
+| type             | String                                                |
+| title            | String                                                |
+| channel          | [IntegrationTaskChannel](#integrationtaskchannel)     |
+| patient          | [Patient](/sdk/data-patient/#patient)                 |
+| service_provider | [ServiceProvider](/sdk/data-service-provider)         |
+| reviews          | [IntegrationTaskReview](#integrationtaskreview)[]     |
+
+#### Properties
+
+| Property     | Type    | Description                                      |
+|--------------|---------|--------------------------------------------------|
+| is_fax       | Boolean | Returns True if this is a fax task               |
+| is_pending   | Boolean | Returns True if task is pending review           |
+| is_processed | Boolean | Returns True if task has been processed          |
+| has_error    | Boolean | Returns True if task has an error status         |
+| is_junked    | Boolean | Returns True if task is junked                   |
+
+### IntegrationTaskReview
+
+| Field Name    | Type                                              |
+|---------------|---------------------------------------------------|
+| id            | UUID                                              |
+| dbid          | Integer                                           |
+| created       | DateTime                                          |
+| modified      | DateTime                                          |
+| task          | [IntegrationTask](#integrationtask)               |
+| template_name | String                                            |
+| document_key  | String                                            |
+| reviewer      | [Staff](/sdk/data-staff/#staff)                   |
+| team_reviewer | [Team](/sdk/data-team/#team)                      |
+| junked        | Boolean                                           |
+
+#### Properties
+
+| Property  | Type    | Description                                |
+|-----------|---------|--------------------------------------------|
+| is_active | Boolean | Returns True if review is not junked       |
+
+## Enumeration types
+
+### IntegrationTaskStatus
+
+| Value | Label        |
+|-------|--------------|
+| UNR   | Unread       |
+| UER   | Unread Error |
+| REA   | Read         |
+| ERR   | Error        |
+| PRO   | Processed    |
+| REV   | Reviewed     |
+| JUN   | Junk         |
+
+### IntegrationTaskChannel
+
+| Value                   | Label                   |
+|-------------------------|-------------------------|
+| fax                     | Fax                     |
+| document_upload         | Document Upload         |
+| from_integration_engine | From Integration Engine |
+| from_patient_portal     | From Patient Portal     |
+
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/data/lab_report_template.md
+++ b/collections/_sdk/data/lab_report_template.md
@@ -70,7 +70,6 @@ results = LabReportTemplate.objects.active().point_of_care().search("a1c")
 
 | Field Name      | Type                                                              |
 |-----------------|-------------------------------------------------------------------|
-| id              | UUID                                                              |
 | dbid            | Integer                                                           |
 | report_template | [LabReportTemplate](#labreporttemplate)                           |
 | sequence        | Integer                                                           |
@@ -86,7 +85,6 @@ results = LabReportTemplate.objects.active().point_of_care().search("a1c")
 
 | Field Name | Type                                                  |
 |------------|-------------------------------------------------------|
-| id         | UUID                                                  |
 | dbid       | Integer                                               |
 | field      | [LabReportTemplateField](#labreporttemplatefield)     |
 | label      | String                                                |

--- a/collections/_sdk/data/lab_report_template.md
+++ b/collections/_sdk/data/lab_report_template.md
@@ -1,0 +1,114 @@
+---
+title: "LabReportTemplate"
+slug: "data-lab-report-template"
+excerpt: "Canvas SDK LabReportTemplate"
+hidden: false
+---
+
+## Introduction
+
+The `LabReportTemplate`, `LabReportTemplateField`, and `LabReportTemplateFieldOption` models represent templates for Point of Care (POC) labs and custom lab reports.
+
+## Basic Usage
+
+To retrieve a `LabReportTemplate` by identifier:
+
+```python
+from canvas_sdk.v1.data.lab_report_template import LabReportTemplate
+
+template = LabReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+```
+
+To access a template's fields and field options:
+
+```python
+from canvas_sdk.v1.data.lab_report_template import LabReportTemplate
+
+template = LabReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+for field in template.fields.all().order_by('sequence'):
+    print(f"Field: {field.label}, Type: {field.field_type}, Required: {field.required}")
+
+    for option in field.options.all():
+        print(f"  Option: {option.label} ({option.key})")
+```
+
+## Filtering
+
+Lab report templates can be filtered by any attribute that exists on the model. The model also provides convenient filter methods for common use cases.
+
+```python
+from canvas_sdk.v1.data.lab_report_template import LabReportTemplate
+
+active_templates = LabReportTemplate.objects.active()
+inactive_templates = LabReportTemplate.objects.inactive()
+matching_templates = LabReportTemplate.objects.search("glucose")
+poc_templates = LabReportTemplate.objects.point_of_care()
+custom_templates = LabReportTemplate.objects.custom()
+builtin_templates = LabReportTemplate.objects.builtin()
+results = LabReportTemplate.objects.active().point_of_care().search("a1c")
+```
+
+## Attributes
+
+### LabReportTemplate
+
+| Field Name      | Type                                                  |
+|-----------------|-------------------------------------------------------|
+| id              | UUID                                                  |
+| dbid            | Integer                                               |
+| name            | String                                                |
+| code            | String                                                |
+| code_system     | String                                                |
+| search_keywords | String                                                |
+| active          | Boolean                                               |
+| custom          | Boolean                                               |
+| poc             | Boolean                                               |
+| fields          | [LabReportTemplateField](#labreporttemplatefield)[]   |
+
+### LabReportTemplateField
+
+| Field Name      | Type                                                              |
+|-----------------|-------------------------------------------------------------------|
+| id              | UUID                                                              |
+| dbid            | Integer                                                           |
+| report_template | [LabReportTemplate](#labreporttemplate)                           |
+| sequence        | Integer                                                           |
+| code            | String                                                            |
+| code_system     | String                                                            |
+| label           | String                                                            |
+| units           | String                                                            |
+| field_type      | [FieldType](#fieldtype)                                           |
+| required        | Boolean                                                           |
+| options         | [LabReportTemplateFieldOption](#labreporttemplatefieldoption)[]   |
+
+### LabReportTemplateFieldOption
+
+| Field Name | Type                                                  |
+|------------|-------------------------------------------------------|
+| id         | UUID                                                  |
+| dbid       | Integer                                               |
+| field      | [LabReportTemplateField](#labreporttemplatefield)     |
+| label      | String                                                |
+| key        | String                                                |
+
+## Enumeration types
+
+### FieldType
+
+| Value        | Label         |
+|--------------|---------------|
+| float        | Float         |
+| select       | Select        |
+| text         | Text          |
+| checkbox     | Checkbox      |
+| radio        | Radio         |
+| array        | Array         |
+| labReport    | Lab Report    |
+| remoteFields | Remote Fields |
+| autocomplete | Autocomplete  |
+| date         | Date          |
+
+<br/>
+<br/>
+<br/>

--- a/collections/_sdk/data/specialty_report_template.md
+++ b/collections/_sdk/data/specialty_report_template.md
@@ -76,7 +76,6 @@ results = SpecialtyReportTemplate.objects.active().custom().by_specialty("207RC0
 
 | Field Name      | Type                                                                          |
 |-----------------|-------------------------------------------------------------------------------|
-| id              | UUID                                                                          |
 | dbid            | Integer                                                                       |
 | report_template | [SpecialtyReportTemplate](#specialtyreporttemplate)                           |
 | sequence        | Integer                                                                       |
@@ -92,7 +91,6 @@ results = SpecialtyReportTemplate.objects.active().custom().by_specialty("207RC0
 
 | Field Name | Type                                                          |
 |------------|---------------------------------------------------------------|
-| id         | UUID                                                          |
 | dbid       | Integer                                                       |
 | field      | [SpecialtyReportTemplateField](#specialtyreporttemplatefield) |
 | label      | String                                                        |

--- a/collections/_sdk/data/specialty_report_template.md
+++ b/collections/_sdk/data/specialty_report_template.md
@@ -1,0 +1,103 @@
+---
+title: "SpecialtyReportTemplate"
+slug: "data-specialty-report-template"
+excerpt: "Canvas SDK SpecialtyReportTemplate"
+hidden: false
+---
+
+## Introduction
+
+The `SpecialtyReportTemplate`, `SpecialtyReportTemplateField`, and `SpecialtyReportTemplateFieldOption` models represent templates for capturing structured data from specialty and referral consultation reports.
+
+## Basic Usage
+
+To retrieve a `SpecialtyReportTemplate` by identifier:
+
+```python
+from canvas_sdk.v1.data.specialty_report_template import SpecialtyReportTemplate
+
+template = SpecialtyReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+print(f"Template: {template.name}")
+print(f"Specialty: {template.specialty_name} ({template.specialty_code})")
+print(f"Active: {template.active}")
+```
+
+To access a template's fields and field options:
+
+```python
+from canvas_sdk.v1.data.specialty_report_template import SpecialtyReportTemplate
+
+template = SpecialtyReportTemplate.objects.get(id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+for field in template.fields.all().order_by('sequence'):
+    print(f"Field: {field.label}, Type: {field.type}, Required: {field.required}")
+
+    for option in field.options.all():
+        print(f"  Option: {option.label} ({option.key})")
+```
+
+## Filtering
+
+Specialty report templates can be filtered by any attribute that exists on the model. The model also provides convenient filter methods for common use cases.
+
+```python
+from canvas_sdk.v1.data.specialty_report_template import SpecialtyReportTemplate
+
+active_templates = SpecialtyReportTemplate.objects.active()
+matching_templates = SpecialtyReportTemplate.objects.search("cardiology")
+custom_templates = SpecialtyReportTemplate.objects.custom()
+builtin_templates = SpecialtyReportTemplate.objects.builtin()
+cardiology_templates = SpecialtyReportTemplate.objects.by_specialty("207RC0000X")
+results = SpecialtyReportTemplate.objects.active().custom().by_specialty("207RC0000X")
+```
+
+## Attributes
+
+### SpecialtyReportTemplate
+
+| Field Name           | Type                                                              |
+|----------------------|-------------------------------------------------------------------|
+| id                   | UUID                                                              |
+| dbid                 | Integer                                                           |
+| name                 | String                                                            |
+| code                 | String                                                            |
+| code_system          | String                                                            |
+| search_keywords      | String                                                            |
+| active               | Boolean                                                           |
+| custom               | Boolean                                                           |
+| search_as            | String                                                            |
+| specialty_name       | String                                                            |
+| specialty_code       | String                                                            |
+| specialty_code_system| String                                                            |
+| fields               | [SpecialtyReportTemplateField](#specialtyreporttemplatefield)[]   |
+
+### SpecialtyReportTemplateField
+
+| Field Name      | Type                                                                          |
+|-----------------|-------------------------------------------------------------------------------|
+| id              | UUID                                                                          |
+| dbid            | Integer                                                                       |
+| report_template | [SpecialtyReportTemplate](#specialtyreporttemplate)                           |
+| sequence        | Integer                                                                       |
+| code            | String                                                                        |
+| code_system     | String                                                                        |
+| label           | String                                                                        |
+| units           | String                                                                        |
+| type            | String                                                                        |
+| required        | Boolean                                                                       |
+| options         | [SpecialtyReportTemplateFieldOption](#specialtyreporttemplatefieldoption)[]   |
+
+### SpecialtyReportTemplateFieldOption
+
+| Field Name | Type                                                          |
+|------------|---------------------------------------------------------------|
+| id         | UUID                                                          |
+| dbid       | Integer                                                       |
+| field      | [SpecialtyReportTemplateField](#specialtyreporttemplatefield) |
+| label      | String                                                        |
+| key        | String                                                        |
+
+<br/>
+<br/>
+<br/>


### PR DESCRIPTION
[KOALA-3886](https://canvasmedical.atlassian.net/browse/KOALA-3886)
[KOALA-3887](https://canvasmedical.atlassian.net/browse/KOALA-3887)
[KOALA-3888](https://canvasmedical.atlassian.net/browse/KOALA-3888)
[KOALA-3889](https://canvasmedical.atlassian.net/browse/KOALA-3889)

Description: 
- Add documentation for IntegrationTask and IntegrationTaskReview data models for managing incoming documents in the Data Integration queue
- Add documentation for LabReportTemplate models for Point of Care (POC) labs and custom lab reports
- Add documentation for SpecialtyReportTemplate models for specialty and referral consultation reports
- Add documentation for ImagingReportTemplate models for imaging report templates


Linked PR:
https://github.com/canvas-medical/canvas-plugins/pull/1357

[KOALA-3886]: https://canvasmedical.atlassian.net/browse/KOALA-3886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KOALA-3887]: https://canvasmedical.atlassian.net/browse/KOALA-3887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KOALA-3888]: https://canvasmedical.atlassian.net/browse/KOALA-3888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KOALA-3889]: https://canvasmedical.atlassian.net/browse/KOALA-3889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ