### PR TITLE
KOALA-3916: Added REMOVE_DOCUMENT_FROM_PATIENT effect

### DIFF
--- a/collections/_sdk/effects.md
+++ b/collections/_sdk/effects.md
@@ -487,6 +487,15 @@ Check out the [HTTP Request](/sdk/effect-http-request/) documentation.
 | SEND_SURESCRIPTS_BENEFITS_REQUEST | Can be used to send a Surescripts benefits request. |
 
 
+### Data Integration
+
+Check out the [Data Integration Effects](/sdk/effect-data-integration/) documentation.
+
+| Effect | Description |
+|---|---|
+| REMOVE_DOCUMENT_FROM_PATIENT | Remove or unlink a document from a patient in the Data Integration queue. |
+
+
 ### Commands
 
 Check out the [Commands documentation](/sdk/commands/) for full details.

--- a/collections/_sdk/effects.md
+++ b/collections/_sdk/effects.md
@@ -493,6 +493,7 @@ Check out the [Data Integration Effects](/sdk/effect-data-integration/) document
 
 | Effect | Description |
 |---|---|
+| CATEGORIZE_DOCUMENT | Categorize a document in the Data Integration queue into a specific document type. |
 | REMOVE_DOCUMENT_FROM_PATIENT | Remove or unlink a document from a patient in the Data Integration queue. |
 
 

--- a/collections/_sdk/effects/data_integration.md
+++ b/collections/_sdk/effects/data_integration.md
@@ -102,6 +102,48 @@ categorize = CategorizeDocument(
 )
 ```
 
+## Removing a Document from a Patient
+
+To remove or unlink a document from a patient in the Data Integration queue, import the `RemoveDocumentFromPatient` class and create an instance of it.
+
+| Attribute   |          | Type          | Description                                                                                                       |
+|-------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------|
+| document_id | required | string        | The ID of the IntegrationTask document to unlink from the patient.                                                |
+| patient_id  | optional | string        | The patient ID to specify which patient link to remove. If not provided, removes the current patient association. |
+
+An example of removing a document from a patient:
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.data_integration import RemoveDocumentFromPatient
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers import BaseHandler
+
+
+class RemoveDocumentHandler(BaseHandler):
+    RESPONDS_TO = EventType.Name(EventType.DOCUMENT_LINKED_TO_PATIENT)
+
+    def compute(self) -> list[Effect]:
+        document_id = self.event.target.id
+
+        remove_document = RemoveDocumentFromPatient(
+            document_id=document_id,
+        )
+
+        return [remove_document.apply()]
+```
+
+If a document could be linked to multiple patients, you can specify which patient to unlink:
+
+```python
+from canvas_sdk.effects.data_integration import RemoveDocumentFromPatient
+
+remove_document = RemoveDocumentFromPatient(
+    document_id="d2194110-5c9a-4842-8733-ef09ea5ead11",
+    patient_id="patient-uuid-here",
+)
+```
+
 <br/>
 <br/>
 <br/>


### PR DESCRIPTION
[KOALA-3916](https://canvasmedical.atlassian.net/browse/KOALA-3916)

Add documentation for Data Integration effect:

- RemoveDocumentFromPatient - Unlink documents from patients

Linked PR:
https://github.com/canvas-medical/canvas-plugins/pull/1395

[KOALA-3916]: https://canvasmedical.atlassian.net/browse/KOALA-3916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ