### PR TITLE
docs: add SGN note state and missing NoteType fields

### DIFF
--- a/collections/_sdk/data/note.md
+++ b/collections/_sdk/data/note.md
@@ -347,6 +347,9 @@ patient_office_visits = Note.objects.filter(patient=patient, note_type_version=n
 | deprecated_at                               | DateTime                                           |
 | is_patient_required                         | Boolean                                            |
 | allow_custom_title                          | Boolean                                            |
+| is_scheduleable_via_patient_portal          | Boolean                                            |
+| online_duration                             | Integer                                            |
+| is_sig_required                             | Boolean                                            |
 
 ### NoteMetadata
 
@@ -411,6 +414,7 @@ for metadata in note_metadata:
 | RCL   | Recalled               |                            |
 | UND   | Undeleted              |                            |
 | DSC   | Discharged             |                            |
+| SGN   | Signed                 | Used when the note type's `is_sig_required` is True |
 | SCH   | Scheduling             | Used in appointment notes  |
 | BKD   | Booked                 | Used in appointment notes  |
 | CVD   | Converted              | Used in appointment notes  |


### PR DESCRIPTION
## Summary

- Adds the missing `SGN` ("Signed") row to the `NoteStates` enumeration table. This state has shipped in the SDK since canvas-plugins `0.85.0` (added in [canvas-medical/canvas-plugins#1292](https://github.com/canvas-medical/canvas-plugins/pull/1292)) but was never reflected in the docs.
- Adds three `NoteType` fields that exist on the SDK model (`canvas_sdk/v1/data/note.py:151-153`) but were missing from the field table:
  - `is_scheduleable_via_patient_portal` (Boolean)
  - `online_duration` (Integer)
  - `is_sig_required` (Boolean) — the toggle that determines whether `SGN` is reachable for a given note.

## Why

Surfaced by [canvas-medical/canvas-plugins#1676](https://github.com/canvas-medical/canvas-plugins/discussions/1676) — a customer saw `SGN` in their data and couldn't find it in the docs or (initially) the SDK. The state is real and current; the documentation just hadn't caught up.

## Test plan

- [ ] Visual check on a docs preview that the new `SGN` row renders in the `NoteStates` table.
- [ ] Visual check that the three new `NoteType` fields render in the field table without breaking column alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)