### PR TITLE
feat: add hidden SDK reference pages for SteadyMD HG additions (KOALA-4854)

### DIFF
--- a/collections/_sdk/effects/health-gorilla-lab-order-ingest.md
+++ b/collections/_sdk/effects/health-gorilla-lab-order-ingest.md
@@ -1,0 +1,83 @@
+---
+title: "Health Gorilla Lab Order Ingest"
+slug: "effect-health-gorilla-lab-order-ingest"
+excerpt: "Push a lab order originated outside Canvas (e.g. on a partner's HG tenant) into Canvas without re-sending to Health Gorilla."
+hidden: true
+---
+
+The `HealthGorillaLabOrderIngest` effect creates a Canvas `LabOrder` plus
+its `LabTest` rows for an order that was placed outside Canvas — for
+example, by a partner on its own Health Gorilla tenant. Canvas records
+the order so it shows up in the chart, but the order's `hg_request_result`
+field is set to a partner-supplied skip-send marker so Canvas's
+send-to-Health-Gorilla worker treats the order as already-sent and never
+forwards it.
+
+Typical use is from a SimpleAPI route the partner POSTs to when they place
+a standing or recurring order on their side.
+
+## Behavior
+
+The effect targets the home-app `HealthGorillaLabOrderIngest` interpreter,
+which in a single transaction:
+
+1. Resolves `Patient` (by `key`), `Staff` (by NPI), and `Note` (by external id).
+2. Creates a `LabOrder` with `hg_request_result` set non-empty so the
+   send-to-HG worker leaves it alone.
+3. Creates one `LabTest` row per HG order code in `test_codes`. Test names
+   are filled from the HG ontology when available.
+
+Each `LabTest` is created with status `RECEIVED`, since externally-originated
+orders are past the Canvas send pipeline.
+
+## Attributes
+
+| Attribute                | Type        | Required | Description                                                                                          |
+| ------------------------ | ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| patient_id               | str         | yes      | Canvas Patient `key` (uuid).                                                                         |
+| ordering_provider_npi    | str         | yes      | NPI used to look up the Staff record.                                                                |
+| note_id                  | str         | yes      | Canvas Note `externally_exposable_id` (uuid). LabOrders require a Note FK in home-app.               |
+| ontology_lab_partner     | str         | yes      | Ontology lab partner name (e.g. `"Quest Diagnostics"`, `"LabCorp"`).                                 |
+| date_ordered             | datetime    | yes      | When the order was authored on the partner side.                                                     |
+| hg_request_result        | str         | yes      | Skip-send marker. Convention is the partner's HG `RequestGroup` URL or id so Canvas can correlate later. Any non-empty value works. |
+| test_codes               | list[str]   | yes      | One or more HG order codes. One `LabTest` row is created per entry.                                  |
+| external_id              | str         | no       | Stored on `LabOrder.healthgorilla_id`; useful for partner-side dedup.                                |
+| comment                  | str         | no       | Stored on `LabOrder.comment`.                                                                        |
+
+## Example
+
+```python
+from datetime import datetime, UTC
+
+from canvas_sdk.effects.lab_order import HealthGorillaLabOrderIngest
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyCredentials, SimpleAPIRoute
+
+
+class StandingLabOrdersAPI(SimpleAPIRoute):
+    PATH = "/standing-lab-orders"
+
+    def authenticate(self, credentials: APIKeyCredentials) -> bool:
+        return credentials.key == self.secrets["ingest-api-key"]
+
+    def post(self) -> list[Response]:
+        body = self.request.json()
+        return [
+            HealthGorillaLabOrderIngest(
+                patient_id=body["patient_id"],
+                ordering_provider_npi=body["ordering_provider_npi"],
+                note_id=body["note_id"],
+                ontology_lab_partner=body["ontology_lab_partner"],
+                date_ordered=datetime.fromisoformat(body["date_ordered"]),
+                hg_request_result=body["hg_request_result"],
+                test_codes=body["test_codes"],
+                external_id=body.get("external_id", ""),
+            ).apply(),
+            JSONResponse({"external_id": body["external_id"]}, status_code=201),
+        ]
+```
+
+## Related
+
+- [`HealthGorillaLabReportIngest`](/sdk/effects/) — the matching effect for inbound lab reports
+- [`HealthGorillaLabOrderOverride`](/sdk/effects/) — for orders Canvas itself sends to HG

--- a/collections/_sdk/effects/health-gorilla-lab-order-override.md
+++ b/collections/_sdk/effects/health-gorilla-lab-order-override.md
@@ -33,8 +33,9 @@ set the same field, the later one wins.
 | practitioner_account_number     | str    | Stamped on the contained `Practitioner.identifier` (Account Number).                                                     |
 | organizational_account_number   | str    | Stamped on the contained authorizing `Organization.identifier` (Account Number).                                         |
 | hg_organization_id              | str    | Health Gorilla facility id (`f-...`) used for the `requestgroup-performer` reference. Skips the lab-name catalog lookup. |
-| hg_tenant_id                    | str    | Health Gorilla sub-tenant Organization id. Adds a `requestgroup-authorizedBy` reference to `Organization/t-{tenant_id}`. |
-| hg_location_id                  | str    | Optional Location reference for the order.                                                                               |
+| hg_tenant_id                    | str    | Health Gorilla sub-tenant Organization id. With `hg_tenant_id` alone, adds a `requestgroup-authorizedBy` reference to `Organization/t-{tenant_id}`. With both `hg_tenant_id` and `hg_location_id` set, the reference is `Organization/tl-{tenant_id}-{location_id}` (the HG sub-tenant location form). |
+| hg_location_id                  | str    | Health Gorilla tenant-location id. Combined with `hg_tenant_id` to produce a `tl-` `requestgroup-authorizedBy` reference. Has no effect on its own. |
+| hg_practitioner_id              | str    | Health Gorilla Practitioner id, appended as an additional identifier on the contained Practitioner with system `https://www.healthgorilla.com`. Use when the ordering provider is registered with HG and you want to surface that registration on the outbound order alongside the NPI. |
 | bill_to_code                    | [BillToCode](#billtocode) | Explicit `Account.type` coding. Overrides the existing coverage-derived inference.                  |
 
 ### BillToCode

--- a/collections/_sdk/effects/health-gorilla-lab-report-ingest.md
+++ b/collections/_sdk/effects/health-gorilla-lab-report-ingest.md
@@ -1,0 +1,95 @@
+---
+title: "Health Gorilla Lab Report Ingest"
+slug: "effect-health-gorilla-lab-report-ingest"
+excerpt: "Push a lab report received outside Canvas (e.g. on a partner's HG tenant) into Canvas with PDF attachment and dedup."
+hidden: true
+---
+
+The `HealthGorillaLabReportIngest` effect creates a Canvas `LabReport`
+plus its `LabValue` rows and attaches a PDF for a result that was
+received outside Canvas — for example, by a partner on its own Health
+Gorilla tenant or any upstream lab interface. It is the inbound
+counterpart to [`HealthGorillaLabOrderIngest`](/sdk/effects/).
+
+The home-app interpreter is equivalent to what
+`LabEngineInboundService.process_and_store_report` does for HG-pull
+ingest, minus the HG fetch — the partner provides the PDF and Canvas
+stores it through the existing S3 + `ElectronicLabIntegrationTask` path.
+
+## Dedup
+
+Reports are deduped server-side on `(external_id, version)`:
+
+| State                                              | Result                                                  |
+| -------------------------------------------------- | ------------------------------------------------------- |
+| New `external_id`                                  | Create new `LabReport`.                                 |
+| Same `external_id`, higher `version`               | Replace values, bump version on existing record, re-store PDF. |
+| Same `external_id`, same or lower `version`        | No-op; existing record kept, no PDF fetch.              |
+
+This matches the version-bump contract in
+`LabEngineInboundService.process_and_store_report`, so partners can
+safely replay events.
+
+## PDF handling
+
+Exactly one of `pdf_url` or `pdf_base64` must be set. The home-app
+interpreter fetches the PDF (or decodes the inline base64) **outside**
+the `LabReport` transaction so a slow partner bucket cannot hold row
+locks. Limits:
+
+- `pdf_base64` capped at 1 MB encoded (~750 KB binary). Use `pdf_url`
+  for larger PDFs.
+- `pdf_url` fetch capped at 10 MB.
+
+## Attributes
+
+| Attribute        | Type           | Required | Description                                                                                                                     |
+| ---------------- | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| lab_order_id     | str            | yes      | Canvas LabOrder `externally_exposable_id` (uuid) the report belongs to.                                                          |
+| patient_id       | str            | yes      | Canvas Patient `key` (uuid).                                                                                                     |
+| external_id      | str            | yes      | Partner-side report id. Used for dedup.                                                                                          |
+| version          | int            | yes      | Report version, monotonically increasing per `external_id`. Must be `>= 1`.                                                      |
+| status           | str            | no       | Report status; defaults to `"final"`.                                                                                            |
+| date_performed   | datetime       | yes      | When the report was generated on the partner side.                                                                               |
+| lab_values       | list[dict]     | yes      | Per-test results. Each entry: `ontology_test_code`, `ontology_test_name`, `value`, `units`, `reference_range`, `abnormal_flag`, `observation_status`, `comment`. |
+| pdf_url          | str            | one of   | URL the home-app interpreter can GET the PDF from (typically a partner's presigned URL).                                          |
+| pdf_base64       | str            | one of   | PDF bytes inline as base64. Use only for small PDFs.                                                                              |
+
+## Example
+
+```python
+from datetime import datetime, UTC
+
+from canvas_sdk.effects.lab_order import HealthGorillaLabReportIngest
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyCredentials, SimpleAPIRoute
+
+
+class ExternalLabReportsAPI(SimpleAPIRoute):
+    PATH = "/external-lab-reports"
+
+    def authenticate(self, credentials: APIKeyCredentials) -> bool:
+        return credentials.key == self.secrets["ingest-api-key"]
+
+    def post(self) -> list[Response]:
+        body = self.request.json()
+        return [
+            HealthGorillaLabReportIngest(
+                lab_order_id=body["lab_order_id"],
+                patient_id=body["patient_id"],
+                external_id=body["external_id"],
+                version=body.get("version", 1),
+                date_performed=datetime.fromisoformat(body["date_performed"]),
+                lab_values=body["lab_values"],
+                pdf_url=body["pdf_url"],
+            ).apply(),
+            JSONResponse(
+                {"external_id": body["external_id"], "version": body.get("version", 1)},
+                status_code=202,
+            ),
+        ]
+```
+
+## Related
+
+- [`HealthGorillaLabOrderIngest`](/sdk/effects/) — the matching effect for inbound lab orders

--- a/collections/_sdk/events/health-gorilla-lab-order-prepared.md
+++ b/collections/_sdk/events/health-gorilla-lab-order-prepared.md
@@ -1,0 +1,64 @@
+---
+title: "Health Gorilla Lab Order Prepared"
+slug: "event-health-gorilla-lab-order-prepared"
+excerpt: "Read-only event fired right after Canvas builds the outbound Health Gorilla RequestGroup and before it is POSTed to HG."
+hidden: true
+---
+
+`HEALTH_GORILLA_LAB_ORDER_PREPARED` fires from Canvas right after the
+outbound Health Gorilla FHIR `RequestGroup` dict is constructed and
+right before it is POSTed to Health Gorilla. Plugin handlers receive
+the prepared dict via the event context and can store it, forward it
+to a partner backend, or surface it in the chart.
+
+The event is **read-only**: it has no associated effect type, and any
+effects a handler returns are discarded. It does not affect the send
+path.
+
+This complements
+[`LAB_ORDER_COMMAND__PRE_SEND`](/sdk/events/), which fires *before* the
+build and lets a plugin inject overrides via
+[`HealthGorillaLabOrderOverride`](/sdk/effects/health-gorilla-lab-order-override).
+The pair gives a plugin both an inject hook and a verify hook on every
+outbound HG order.
+
+## Event context
+
+The plugin handler receives `self.event.context` as a JSON-serialized
+dict with the following keys:
+
+| Key             | Type     | Description                                                                                                       |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| lab_order       | dict     | `{"id": "<uuid>", "uuid": "<uuid>"}` — the LabOrder external id.                                                  |
+| lab_partner     | str      | Ontology lab partner name (`order.ontology_lab_partner`).                                                         |
+| patient         | dict     | `{"id": "<key>"}` if the order has a patient, else `{}`.                                                          |
+| note            | dict     | `{"id": "<uuid>", "uuid": "<uuid>"}` — only present when the order has a Note FK.                                 |
+| request_group   | dict     | The full FHIR `RequestGroup` as it will be POSTed to HG, including all overrides applied by `LAB_ORDER_COMMAND__PRE_SEND` handlers. |
+
+## Example
+
+```python
+import json
+
+from canvas_generated.messages.events_pb2 import EventType
+from canvas_sdk.handlers.base import BaseHandler
+
+
+class LogHGPayload(BaseHandler):
+    """Capture every outbound HG RequestGroup for partner verification."""
+
+    RESPONDS_TO = EventType.Name(EventType.HEALTH_GORILLA_LAB_ORDER_PREPARED)
+
+    def compute(self):
+        context = json.loads(self.event.context)
+        request_group = context["request_group"]
+        lab_order_id = context["lab_order"]["id"]
+        # store / forward / display the dict however you need
+        return []  # no effect type associated with this event
+```
+
+## Related
+
+- [`LAB_ORDER_COMMAND__PRE_SEND`](/sdk/events/) — fires *before* the build, accepts override effects
+- [`HealthGorillaLabOrderOverride`](/sdk/effects/health-gorilla-lab-order-override) — the override effect returned from PRE_SEND
+- [HG `RequestGroup` profile](https://developer.healthgorilla.com/docs/requestgroup)


### PR DESCRIPTION
[KOALA-4854](https://canvasmedical.atlassian.net/browse/KOALA-4854) follow-up.

Companions:
- canvas-medical/canvas-plugins#1680
- canvas-medical/canvas#19009

## Summary

Adds three new SDK reference pages and extends one existing page for the SteadyMD HG additions. All pages are `hidden: true` and not added to the public SDK sidebar — same posture as the original \`HealthGorillaLabOrderOverride\` page (intentionally low-discovery; reachable by direct URL for the plugin author who needs the reference).

**Should not appear in customer-facing release notes.**

## What changed

- \`health-gorilla-lab-order-override.md\` (existing) — extended with the new \`hg_practitioner_id\` field row and updated \`hg_tenant_id\` / \`hg_location_id\` descriptions to reflect the new \`Organization/tl-{tenant}-{location}\` \`requestgroup-authorizedBy\` semantics when both are set.
- \`health-gorilla-lab-order-ingest.md\` (new) — \`HealthGorillaLabOrderIngest\` effect: push a lab order originated outside Canvas (e.g. on a partner's HG tenant) into Canvas without re-sending to HG. Documents the \`hg_request_result\` skip-send marker contract.
- \`health-gorilla-lab-report-ingest.md\` (new) — \`HealthGorillaLabReportIngest\` effect: push a lab report received outside Canvas with PDF attachment. Documents the \`(external_id, version)\` dedup table and PDF size caps.
- \`health-gorilla-lab-order-prepared.md\` (new) — \`HEALTH_GORILLA_LAB_ORDER_PREPARED\` event: read-only post-build verification hook for the outbound HG RequestGroup, complementing \`LAB_ORDER_COMMAND__PRE_SEND\`.

## Test plan

- [x] All four pages have \`hidden: true\` in front matter.
- [x] No \`_data/menus.yml\` entries — pages are reachable only by direct URL.
- [x] Cross-links between pages use the same slug format as the existing override page.

[KOALA-4854]: https://canvasmedical.atlassian.net/browse/KOALA-4854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ