### PR TITLE
feat: docs for new plugin logs filters

### DIFF
--- a/collections/_sdk/canvas_cli.md
+++ b/collections/_sdk/canvas_cli.md
@@ -234,6 +234,8 @@ $ canvas logs [OPTIONS]
 -  `--no-follow`:          Historical only; do not stream live logs.
 -  `--level TEXT`:         Repeatable. --level ERROR --level WARN
 -  `--source TEXT`:        Filter by source/service.
+-  `--plugin TEXT`:        Repeatable. --plugin foo --plugin bar.
+-  `--handler TEXT`:       Repeatable. Qualified handler name (e.g. my_plugin.handlers.Foo).
 -  `--page-size INTEGER`:  Fetch size per page (historical).  \[default: 200]
 -  `--limit INTEGER`:      Max historical logs to print.
 -  `--all`:                Fetch all pages until exhausted (historical).

--- a/collections/_sdk/plugin-logs.md
+++ b/collections/_sdk/plugin-logs.md
@@ -23,9 +23,13 @@ Navigation path:
 The UI lets you:
 - Filter by **source** (e.g., `plugin-runner`, `effect-interpreter`)
 - Filter by **level** (`ERROR`, `WARN`, `INFO`, `DEBUG`)
+- Filter by **plugin** — multi-select; the dropdown is pre-populated with plugins seen in the last 7 days, and accepts free-text entries for older or yet-to-log plugins
+- Filter by **handler** — multi-select on the fully-qualified handler class; works the same as plugin (last 7 days + free-text)
 - Filter by **time** (start/end)
 - Inspect **full JSON** of a log entry in a modal
 - **Load more** results without leaving the page
+
+The results table shows columns for `@timestamp`, `level`, `source`, `plugin`, and `message`. Click a row to open the full log entry as JSON.
 
 {% include alert.html type="info" content="The UI defaults to showing the most recent logs first (sorted by <code>@timestamp desc</code>)." %}
 
@@ -57,6 +61,21 @@ $ canvas logs --level ERROR
 
 # Errors and warnings:
 $ canvas logs --level ERROR --level WARN
+```
+
+##### Filter by plugin / handler (repeatable)
+```console
+# One plugin:
+$ canvas logs --plugin my_plugin
+
+# Multiple plugins:
+$ canvas logs --plugin my_plugin --plugin other_plugin
+
+# A specific handler (fully qualified class name):
+$ canvas logs --handler my_plugin.handlers.foo.MyHandler
+
+# Multiple handlers:
+$ canvas logs --handler my_plugin.handlers.foo.MyHandler --handler my_plugin.handlers.bar.OtherHandler
 ```
 
 ##### Time windows: since / start / end
@@ -108,7 +127,7 @@ More available. To load the next page, run:
   --cursor <TOKEN>
 ```
 
-{% include alert.html type="warning" content="<code>--cursor</code> is <b>mutually exclusive</b> with filters (<code>--since</code>, <code>--start/--end</code>, <code>--level</code>, <code>--source</code>) to enforce consistency. Use the token alone to resume" %}.
+{% include alert.html type="warning" content="<code>--cursor</code> is <b>mutually exclusive</b> with filters (<code>--since</code>, <code>--start/--end</code>, <code>--level</code>, <code>--source</code>, <code>--plugin</code>, <code>--handler</code>) to enforce consistency. Use the token alone to resume" %}.
 
 ---
 


### PR DESCRIPTION
[KOALA-5386](https://canvasmedical.atlassian.net/browse/KOALA-5386)

This pull request updates the documentation for the Canvas CLI and plugin logs UI to add support for filtering logs by plugin and handler, both in the CLI and the UI. The changes also clarify mutual exclusivity of filters when paginating with cursors.

Key changes include:

**CLI Documentation Updates:**

* Added `--plugin` and `--handler` repeatable options to the `$ canvas logs` command, allowing users to filter logs by plugin name or fully qualified handler class name.
* Added usage examples demonstrating how to use the new `--plugin` and `--handler` options with the CLI.

**UI Documentation Updates:**

* Updated the UI documentation to describe new multi-select filters for plugin and handler, including their behavior (pre-populated with recent entries and accepting free-text).
* Noted that the results table now includes columns for `@timestamp`, `level`, `source`, `plugin`, and `message`.

**Filter Exclusivity Clarification:**

* Extended the warning about the `--cursor` option to include the new `--plugin` and `--handler` filters as mutually exclusive with other filters for consistent pagination.

[KOALA-5386]: https://canvasmedical.atlassian.net/browse/KOALA-5386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ