### PR TITLE
Use Handler terminology (not Protocol) in plugin tutorials

### DIFF
--- a/collections/_guides/appointments-additional_fields.md
+++ b/collections/_guides/appointments-additional_fields.md
@@ -63,7 +63,7 @@ from canvas_sdk.handlers import BaseHandler
 
 
 # Inherit from BaseHandler to properly get registered for events
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.APPOINTMENT__FORM__GET_ADDITIONAL_FIELDS)
 
     def compute(self) -> list[Effect]:

--- a/collections/_guides/creating-webhooks-with-the-canvas-sdk.md
+++ b/collections/_guides/creating-webhooks-with-the-canvas-sdk.md
@@ -43,7 +43,7 @@ from canvas_sdk.handlers import BaseHandler
 from logger import log
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """
     When a task is created, log a message
     """
@@ -69,9 +69,9 @@ created a task, you should see this in your log stream:
 ```sh
 INFO 2024-09-26 17:04:08,396 Starting server, listening on port 50051
 INFO 2024-09-26 17:04:08,396 Loading custom-plugins/task_webhook
-INFO 2024-09-26 17:04:08,396 Loading plugin 'task_webhook:task_webhook.handlers.event_handlers:Protocol'
+INFO 2024-09-26 17:04:08,396 Loading plugin 'task_webhook:task_webhook.handlers.event_handlers:Handler'
 INFO 2024-09-26 17:04:24,410 A Task was created!
-INFO 2024-09-26 17:04:24,410 task_webhook:task_webhook.handlers.event_handlers:Protocol.compute() completed (0 ms)
+INFO 2024-09-26 17:04:24,410 task_webhook:task_webhook.handlers.event_handlers:Handler.compute() completed (0 ms)
 INFO 2024-09-26 17:04:24,411 Responded to Event TASK_CREATED (1 ms)
 ```
 
@@ -92,7 +92,7 @@ from canvas_sdk.utils import Http
 from logger import log
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """
     When a task is created, hit a webhook
     """
@@ -125,9 +125,9 @@ created a task, you should see this in your log stream:
 
 ```sh
 INFO 2024-09-26 17:18:23,206 Loading custom-plugins/task_webhook
-INFO 2024-09-26 17:18:23,207 Reloading plugin 'task_webhook:task_webhook.handlers.event_handlers:Protocol'
+INFO 2024-09-26 17:18:23,207 Reloading plugin 'task_webhook:task_webhook.handlers.event_handlers:Handler'
 INFO 2024-09-26 17:18:33,850 Successfully notified API of task creation!
-INFO 2024-09-26 17:18:33,851 task_webhook:task_webhook.handlers.event_handlers:Protocol.compute() completed (693 ms)
+INFO 2024-09-26 17:18:33,851 task_webhook:task_webhook.handlers.event_handlers:Handler.compute() completed (693 ms)
 INFO 2024-09-26 17:18:33,851 Responded to Event TASK_CREATED (696 ms)
 ```
 
@@ -151,7 +151,7 @@ specifically going to incorporate the event's `target` and `secrets`.
 
 ### Make an authenticated HTTP request that includes the newly created Task's ID
 
-Within your `Protocol` class, you have access to `self.target`, which
+Within your `Handler` class, you have access to `self.target`, which
 represents the ID of the subject of the event. In our case, it will be the
 Task's ID. This is the same ID used in the [FHIR Task endpoints](/api/task/),
 so you can use it to make FHIR API requests.
@@ -173,7 +173,7 @@ auth token. Here's what the manifest file looks like with secrets declared:
     "components": {
         "handlers": [
             {
-                "class": "task_webhook.handlers.event_handlers:Protocol",
+                "class": "task_webhook.handlers.event_handlers:Handler",
                 "description": "Hit an API when a task is created",
                 "data_access": {
                     "event": "",
@@ -214,7 +214,7 @@ from canvas_sdk.utils import Http
 from logger import log
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """
     When a task is created, hit a webhook
     """
@@ -267,7 +267,7 @@ from canvas_sdk.utils import Http
 from logger import log
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """
     When a task is created or updated, hit a webhook
     """

--- a/collections/_guides/custom-landing-page.md
+++ b/collections/_guides/custom-landing-page.md
@@ -43,7 +43,7 @@ from canvas_sdk.effects.widgets import PortalWidget
 from canvas_sdk.events import EventType
 from canvas_sdk.handlers import BaseHandler
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.PATIENT_PORTAL__WIDGET_CONFIGURATION)
 
     def compute(self):
@@ -264,7 +264,7 @@ from canvas_sdk.templates import render_to_string
 from canvas_sdk.v1.data import Patient
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.PATIENT_PORTAL__WIDGET_CONFIGURATION)
 
     def compute(self):

--- a/collections/_guides/customize-search-results.md
+++ b/collections/_guides/customize-search-results.md
@@ -50,7 +50,7 @@ from canvas_sdk.effects import Effect, EffectType
 from canvas_sdk.handlers import BaseHandler
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.MEDICATION_STATEMENT__MEDICATION__POST_SEARCH)
 
     def compute(self):
@@ -99,7 +99,7 @@ from canvas_sdk.events import EventType
 from canvas_sdk.handlers import BaseHandler
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.MEDICATION_STATEMENT__MEDICATION__POST_SEARCH)
 
     def compute(self):

--- a/collections/_guides/growth-charts.md
+++ b/collections/_guides/growth-charts.md
@@ -225,7 +225,7 @@ from canvas_sdk.templates import render_to_string
 who_boys_length_age = ... # from growth_charts.graphs.who_boys_length_age
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     def compute(self):
         # list of graphs
         length_for_age = {} # filled in the actual implementation, see linked GitHub repository

--- a/collections/_guides/patient-chart-group-items.md
+++ b/collections/_guides/patient-chart-group-items.md
@@ -32,7 +32,7 @@ from canvas_sdk.events import EventType
 from canvas_sdk.handlers import BaseHandler
 from canvas_sdk.commands.constants import CodeSystems
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.PATIENT_CHART__CONDITIONS)
 
     def compute(self) -> list[Effect]:

--- a/collections/_guides/patient-portal-forms.md
+++ b/collections/_guides/patient-portal-forms.md
@@ -39,8 +39,8 @@ INTAKE_QUESTIONNAIRES = [
 ]
 
 
-class Protocol(BaseHandler):
-  """Protocol for processing Patient Portal form requests and generating form effects."""
+class Handler(BaseHandler):
+  """Handler for processing Patient Portal form requests and generating form effects."""
 
   RESPONDS_TO = EventType.Name(EventType.PATIENT_PORTAL__GET_FORMS)
 
@@ -97,9 +97,9 @@ class Protocol(BaseHandler):
 3. If applicable, the response can create a Questionnaire Command inside a Note using the [form result effect](/sdk/form-result-effect/).
 4. The developer is responsible for ensuring that forms do not persist unnecessarily.
 
-## Adding Form Logic in a Protocol Handler
+## Adding Form Logic in a Handler
 
-We define a **Protocol** that listens for `PATIENT_PORTAL__GET_FORMS` events and determines which forms need to be
+We define a **Handler** that listens for `PATIENT_PORTAL__GET_FORMS` events and determines which forms need to be
 displayed.
 
 

--- a/collections/_guides/profile-additional-fields.md
+++ b/collections/_guides/profile-additional-fields.md
@@ -61,7 +61,7 @@ from canvas_sdk.handlers import BaseHandler
 
 
 # Inherit from BaseHandler to properly get registered for events
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.PATIENT_METADATA__GET_ADDITIONAL_FIELDS)
 
     def compute(self) -> list[Effect]:

--- a/collections/_guides/scribe-ai-parser.md
+++ b/collections/_guides/scribe-ai-parser.md
@@ -104,7 +104,7 @@ Once the content is pasted in, the plugin does the rest. Here's how.
 
 #### 1. Handler Class
 
-The `Protocol` class intercepts events and processes the transcript using a parser.
+The `Handler` class intercepts events and processes the transcript using a parser.
 
 ```python
 from canvas_sdk.handlers import BaseHandler
@@ -115,7 +115,7 @@ from canvas_sdk.events import EventType
 class ScribeParser: ...  # explained in section 2 below, "ScribeParser"
 
 
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """A Plugin for interpreting transcripts."""
 
     RESPONDS_TO = EventType.Name(EventType.CLIPBOARD_COMMAND__POST_INSERTED_INTO_NOTE)
@@ -248,7 +248,7 @@ class CustomParser(TranscriptParser):
         ...
 ```
 
-Replace the parser in the `Protocol` class:
+Replace the parser in the `Handler` class:
 
 ```python
 from canvas_sdk.handlers import BaseHandler
@@ -258,8 +258,8 @@ from canvas_sdk.effects import Effect
 class CustomParser: ... # defined above
 
 
-class Protocol(BaseHandler):
-    """Protocol using a custom parser."""
+class Handler(BaseHandler):
+    """Handler using a custom parser."""
 
     def compute(self) -> list[Effect]:
         transcript = self.context["fields"]["text"]

--- a/collections/_guides/your-first-plugin.md
+++ b/collections/_guides/your-first-plugin.md
@@ -112,7 +112,7 @@ installation of the plugin.
     "components": {
         "handlers": [
             {
-                "class": "paperwork_eviscerator.handlers.event_handlers:Protocol",
+                "class": "paperwork_eviscerator.handlers.event_handlers:Handler",
                 "description": "A handler that does xyz...",
                 "data_access": {
                     "event": "",
@@ -163,7 +163,7 @@ from logger import log
 
 
 # Inherit from BaseHandler to properly get registered for events
-class Protocol(BaseHandler):
+class Handler(BaseHandler):
     """
     You should put a helpful description of this handler's behavior here.
     """

--- a/collections/_sdk/examples/patient_summary_chart_groups.md
+++ b/collections/_sdk/examples/patient_summary_chart_groups.md
@@ -49,7 +49,7 @@ A plugin that groups Psychiatry conditions and medications in the patient summar
 
 ## handlers/
 
-### my_protocol.py
+### my_handler.py
 
 This file defines two custom handlers, `Conditions` and `Medications`, using the Canvas SDK. These handlers listen for specific events related to a patient's medical chart and group relevant diagnoses or medications into a "Psychiatry" category, returning these as effects for further processing or display in the Canvas UI.
 

--- a/collections/_sdk/handlers/simple-api/api.md
+++ b/collections/_sdk/handlers/simple-api/api.md
@@ -19,13 +19,13 @@ project. For this exercise, use `my_api` as your project (i.e. plugin) name.
 
 Open `CANVAS_MANIFEST.json` in your editor. You can modify filenames, directory structures, and
 class names as you see fit in your project, but for this exercise, we are just going to set the
-value at `components -> handlers -> 0 -> class` to be `my_api.handlers.my_protocol:MyAPI`.
+value at `components -> handlers -> 0 -> class` to be `my_api.handlers.my_handler:MyAPI`.
 
 We're going to need a secret value for authentication. The instructions for declaring secrets are
 outlined on the [Your First Plugin (Manual)](https://docs.canvasmedical.com/guides/your-first-plugin/) page.
 Declare a secret in `CANVAS_MANIFEST.json` named `my-api-key`.
 
-Open `my_api/handlers/my_protocol.py` and replace the contents of the file with this code:
+Open `my_api/handlers/my_handler.py` and replace the contents of the file with this code:
 
 ```python
 from hmac import compare_digest


### PR DESCRIPTION
## Summary

Renames the canonical handler class name in plugin tutorials from `Protocol(BaseHandler)` to `Handler(BaseHandler)`, plus the matching manifest entries, log output, and a handful of file/heading references that used `my_protocol.py` / "Protocol Handler".

## Why

In the SDK, `BaseHandler` is the canonical base class and `handlers/` is the canonical directory. `BaseProtocol` is kept as a thin back-compat subclass of `BaseHandler`. The word "protocol" is reserved for true clinical protocols — the `canvas_sdk.protocols` module, the `/sdk/protocols/` and `/learn/protocols/` pages, `ClinicalQualityMeasure`, etc.

The plugin tutorials still teach the legacy shape, which makes the example `class Protocol(BaseHandler):` look like the convention. This propagates into LLM-assisted tooling: the `canvas-medical/coding-agents` repo bundles `sdk-context.txt` from this repo, so any agent reading it learns the legacy convention and then scaffolds new plugins with it. Downstream cleanup just landed in `canvas-medical/coding-agents#80` and `#84` — this PR is the upstream half so the next sync doesn't reintroduce the old terms.

## Files changed

| File | What changed |
|---|---|
| `_guides/your-first-plugin.md` | Class + manifest entry |
| `_guides/creating-webhooks-with-the-canvas-sdk.md` | 4 class definitions, 4 plugin-log lines, manifest entry, narrative reference |
| `_guides/profile-additional-fields.md` | Class |
| `_guides/scribe-ai-parser.md` | 2 class definitions, 2 narrative references, docstring |
| `_guides/customize-search-results.md` | 2 class definitions |
| `_guides/custom-landing-page.md` | 2 class definitions |
| `_guides/patient-portal-forms.md` | Class + docstring; "Adding Form Logic in a Protocol Handler" heading and prose |
| `_guides/appointments-additional_fields.md` | Class |
| `_guides/growth-charts.md` | Class |
| `_guides/patient-chart-group-items.md` | Class |
| `_sdk/handlers/simple-api/api.md` | `my_protocol.py` → `my_handler.py`; matching manifest class path |
| `_sdk/examples/patient_summary_chart_groups.md` | `### my_protocol.py` → `### my_handler.py` |

## Deliberately out of scope

These uses of "protocol" are correct as written:

- `_data/menus.yml` — `/learn/protocols/` and `/sdk/protocols/` menu entries point at the clinical-protocols pages.
- `_sdk/handlers.md:10` — describes clinical Protocols as a special handler type, links to `/sdk/protocols/`.
- `_guides/customize-search-results.md:7` — `permalink:` front-matter; changing it would break URLs.
- `_guides/growth-charts.md:73,164` — `render_to_string("protocols/hello-world.html", ...)` (a template path) and a GitHub URL to an external repo, both out of scope here.

## Regenerated context files

`sdk-context.txt` is regenerated automatically by `.github/workflows/generate-context.yml` on push to main, so it's not included in this PR. The workflow will commit the regenerated file after merge.

## Test plan

- [x] `grep -rEn "class Protocol\(BaseHandler|MyProtocol|my_protocol\.py|from canvas_sdk\.protocols import" collections/ pages/ _data/` returns nothing.
- [ ] Reviewer: spot-check that no narrative was over-rewritten — the goal is to remove `Protocol` only where it referred to the generic handler class name, not where it referred to clinical protocols.
- [ ] Confirm `test-code-blocks` CI still passes (the rename is a valid Python identifier change with no cross-block references).
