### PR TITLE
Enable Algolia Insights for click and conversion analytics

### DIFF
--- a/_js/algolia.js
+++ b/_js/algolia.js
@@ -7,6 +7,7 @@ window.addEventListener('load', () => {
     const search = instantsearch({
         indexName: algoliaIndex,
         searchClient,
+        insights: true,
 
         searchFunction(helper) {
             const searchResults = document.getElementById('search_container');


### PR DESCRIPTION
## What

Enable Algolia Insights in the docs search by setting `insights: true` in the InstantSearch configuration.

## Why

The docs index currently logs raw search queries but no click or conversion data. The Algolia Analytics dashboard shows `# events: 0`, meaning we have zero visibility into:

- Click-through rate per search
- Position of clicked results
- Searches that returned results but got no click

This data is included in our existing Grow plan at no additional cost.

## What changes downstream

- Algolia dashboard will start populating Click Analytics, Conversion Analytics, and Position views
- Anonymous user tokens are generated by the `search-insights` library (cookie-based, same browser = same token)
- No PII captured; no GDPR/CCPA impact beyond the existing search cookie

## Verification after merge

1. Visit docs.canvasmedical.com, run a few searches, click some results
2. In Algolia dashboard for `docs_canvasmedical`, check Analytics -> Click Analytics within ~10 min - events should start appearing
3. Confirm `# events` on the index page is > 0