### PR TITLE
Add PostHog analytics to capture pageviews, session replay, and search queries

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,4 +13,5 @@
 
 {% if (jekyll.environment == 'production' or jekyll.environment == 'pwa') %}
 {% include google-analytics.html %}
+{% include posthog.html %}
 {% endif %}

--- a/_includes/posthog.html
+++ b/_includes/posthog.html
@@ -1,0 +1,7 @@
+<script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture identify reset alias group on register unregister opt_out_capturing opt_in_capturing has_opted_out_capturing has_opted_in_capturing get_distinct_id get_session_id get_property set_config startSessionRecording stopSessionRecording captureException debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_nkYV8XSPsJDs5zWKZ2pnJQESWq3eVZrXXRuoS9zxKaTH', {
+        api_host: 'https://us.i.posthog.com',
+        person_profiles: 'identified_only'
+    })
+</script>

--- a/_js/algolia.js
+++ b/_js/algolia.js
@@ -31,7 +31,12 @@ window.addEventListener('load', () => {
             showLoadingIndicator: true,
             queryHook(query, refine) {
                 clearTimeout(timerId);
-                timerId = setTimeout(() => refine(query), 500);
+                timerId = setTimeout(() => {
+                    refine(query);
+                    if (query && window.posthog) {
+                        window.posthog.capture('docs_search', { query: query });
+                    }
+                }, 500);
             },
         }),
     );


### PR DESCRIPTION
## What

Wires up PostHog on docs.canvasmedical.com to complement the existing Google Analytics and Algolia search analytics.

Three changes:

- **NEW `_includes/posthog.html`** - standard PostHog snippet with the public `phc_` project token. `person_profiles` is set to `identified_only` so anonymous docs traffic does not inflate the PostHog person quota.
- **`_includes/head.html`** - include `posthog.html` inside the existing production/pwa env guard, so PostHog only loads in deployed environments and not in local dev.
- **`_js/algolia.js`** - fire a `docs_search` custom event from the existing `queryHook` so PostHog captures every search query alongside the queries Algolia is already logging.

## Why

GA4 captures pageviews but no search events. Algolia captures search queries but no behavioral data. PostHog fills the gap with:

- Session replay (watch real users navigate the docs)
- Heatmaps and click maps
- Funnel analysis (e.g., searched -> clicked -> bounced)
- Cross-property analytics if we later add the same project token to canvasmedical.com or trial.canvasmedical.com

## Cookies / privacy

PostHog drops first-party anonymous cookies (random UUID, no PII). Same legal posture as the existing GA4 setup, which already drops cookies under the site's existing cookie consent banner ([_includes/cookie-consent.html](../blob/main/_includes/cookie-consent.html)). No new compliance gap introduced.

## What can't break

The PostHog snippet loads asynchronously, and the `posthog.capture` call in `algolia.js` is wrapped in `if (query && window.posthog)`. If PostHog fails to load or is blocked, search continues to work unchanged.

## Verification after merge

1. Visit docs.canvasmedical.com - PostHog should appear in browser DevTools -> Network as a request to `us.i.posthog.com`
2. Run a few searches on the docs site
3. In PostHog (project "Canvas Web - All"), go to **Product analytics -> Events** - both `$pageview` and `docs_search` events should appear within ~30 seconds
4. Optional: enable session replay in **Project Settings -> Session Replay** to start capturing recordings