### PR TITLE
feat: add approve and deny refill command events

### DIFF
--- a/collections/_sdk/events.md
+++ b/collections/_sdk/events.md
@@ -16179,16 +16179,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16211,16 +16204,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16243,16 +16229,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16275,16 +16254,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16307,16 +16279,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16339,16 +16304,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16371,16 +16329,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16403,16 +16354,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16435,16 +16379,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16467,16 +16404,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16519,16 +16449,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16551,16 +16474,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16583,16 +16499,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16615,16 +16524,9 @@ Refer to the [base context documentation](#context-overview) for additional deta
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
   "prescribe": dict
-  "indications": list[dict]
-  "sig": str
-  "days_supply": int
-  "quantity_to_dispense": int
-  "type_to_dispense": dict
   "refills": int
-  "substitutions": str
-  "pharmacy": dict
-  "prescriber": dict
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16648,8 +16550,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16671,8 +16576,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16694,8 +16602,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16717,8 +16628,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16740,8 +16654,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16763,8 +16680,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16786,8 +16706,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16809,8 +16732,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16832,8 +16758,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16855,8 +16784,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16898,8 +16830,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16921,8 +16856,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16944,8 +16882,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":
@@ -16967,8 +16908,11 @@ Refer to the [base context documentation](#context-overview) for additional deta
       <td><pre>"id": command_uuid
 "type": <a href='/sdk/data-command/'>Command</a></pre></td>
       <td><pre>"fields":
-  "reason": str
+  "prescribe": dict
+  "response_type": str
+  "reason_code": str
   "note_to_pharmacist": str
+  "refill_request": int
 "note":
   "uuid": note_id
 "patient":

--- a/collections/_sdk/events.md
+++ b/collections/_sdk/events.md
@@ -16163,6 +16163,820 @@ Refer to the [base context documentation](#context-overview) for additional deta
   </tbody>
 </table>
 
+#### Approve Refill Command
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_ORIGINATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_ORIGINATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_UPDATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_UPDATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_COMMIT</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_COMMIT</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_DELETE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_DELETE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_ENTER_IN_ERROR</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_ENTER_IN_ERROR</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__AVAILABLE_ACTIONS</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"actions":
+  "name": string
+"user":
+  "staff": staff_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_VALIDATION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__PRE_EXECUTE_ACTION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_EXECUTE_ACTION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">APPROVE_REFILL_COMMAND__POST_INSERTED_INTO_NOTE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "prescribe": dict
+  "indications": list[dict]
+  "sig": str
+  "days_supply": int
+  "quantity_to_dispense": int
+  "type_to_dispense": dict
+  "refills": int
+  "substitutions": str
+  "pharmacy": dict
+  "prescriber": dict
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+#### Deny Refill Command
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_ORIGINATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_ORIGINATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_UPDATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_UPDATE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_COMMIT</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_COMMIT</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_DELETE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_DELETE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_ENTER_IN_ERROR</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_ENTER_IN_ERROR</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__AVAILABLE_ACTIONS</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"actions":
+  "name": string
+"user":
+  "staff": staff_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_VALIDATION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__PRE_EXECUTE_ACTION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_EXECUTE_ACTION</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr><th colspan="2">DENY_REFILL_COMMAND__POST_INSERTED_INTO_NOTE</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target object</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>"id": command_uuid
+"type": <a href='/sdk/data-command/'>Command</a></pre></td>
+      <td><pre>"fields":
+  "reason": str
+  "note_to_pharmacist": str
+"note":
+  "uuid": note_id
+"patient":
+  "id": pt_id</pre></td>
+    </tr>
+  </tbody>
+</table>
+
 #### Refill Prescription Command
 
 <table>

--- a/pages/commands-module.md
+++ b/pages/commands-module.md
@@ -271,12 +271,12 @@ Commands migrated to the new framework will function similarly if not identicall
     </tr>
     <tr>
       <td>Approve Refill</td>
-      <td><span class="tag-next-up"> Next up </span> </td>
+      <td><span class="tag-beta-testing"> Released - Beta </span> </td>
       <td></td>
     </tr>
     <tr>
       <td>Deny Refill</td>
-      <td><span class="tag-next-up"> Next up </span> </td>
+      <td><span class="tag-beta-testing"> Released - Beta </span> </td>
       <td></td>
     </tr>
   </tbody>


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-4345
https://canvasmedical.atlassian.net/browse/KOALA-4347

## Summary
- Documents the 15 protobuf event types for `ApproveRefillCommand` and `DenyRefillCommand` introduced in canvas-medical/canvas-plugins#1698.
- Approve Refill exposes the same field set as `RefillCommand` (`prescribe`, `indications`, `sig`, `days_supply`, `quantity_to_dispense`, `type_to_dispense`, `refills`, `substitutions`, `pharmacy`, `prescriber`, `note_to_pharmacist`). Deny Refill exposes `reason` and `note_to_pharmacist`.
- Promotes the two existing Commands Matrix rows from `Next up` to `Released - Beta`, matching how Visual Exam Finding was rolled out in #1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)