### PR TITLE
docs: Agent Runner Framework SDK docs (preview) [KOALA-5544]

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -663,6 +663,9 @@ sdk:
 sdk_overview:
   - title: "Introduction"
     url: /sdk/
+  - title: "Agent Runner Framework"
+    url: /sdk/agents/
+    identifier: sdk_agents
   - title: "Caching Module"
     url: /sdk/caching/
   - title: "Clients Module"
@@ -783,7 +786,23 @@ integrations:
     url: /sdk/example-sendgrid_email/
   - title: "Twilio SMS/MMS"
     url: /sdk/example-twilio_sms_mms/
-  
+
+sdk_agents:
+  - title: "Quick Start"
+    url: /sdk/agents-quick-start/
+  - title: "Lifecycle"
+    url: /sdk/agents-lifecycle/
+  - title: "Managing State"
+    url: /sdk/agents-managing-state/
+  - title: "Tools"
+    url: /sdk/agents-tools/
+  - title: "Prompts"
+    url: /sdk/agents-prompts/
+  - title: "Testing"
+    url: /sdk/agents-testing/
+  - title: "Auditing"
+    url: /sdk/agents-auditing/
+
 sdk_handlers:
   - title: "Action Buttons"
     url: /sdk/handlers-action-buttons/

--- a/collections/_sdk/agents.md
+++ b/collections/_sdk/agents.md
@@ -1,0 +1,167 @@
+---
+title: "Agent Runner Framework"
+disable_anchorlist: true
+---
+
+The Agent Runner Framework lets you deploy LLM-driven agents as Canvas
+plugins. An agent has read access to a patient's chart, can call tools you
+define (and tools the SDK ships), and emits Canvas [Effects](/sdk/effects/)
+that the platform dispatches — drafting commands on a note, creating
+tasks, surfacing recommendations to clinicians, and so on. Unlike a
+[BaseHandler](/sdk/handlers-basehandler/), an agent's `run()` is allowed to
+take seconds (or minutes, for tool-heavy workflows) — it runs on a
+worker, not on the request thread.
+
+> This framework is currently in preview. The shape of the SDK is
+> stable, but some features described here are scheduled for upcoming
+> releases — those are called out inline.
+
+## When agents fit
+
+Anything where the right next step depends on reasoning over multiple
+parts of a chart, where the answer isn't deterministic, and where a
+clinician will review what the agent staged.
+
+Examples:
+
+- **Note drafting** — read the chart on note creation, draft a Plan
+  command on the new note for the clinician to edit and commit.
+- **Longitudinal care surveillance** — at note lock, check whether
+  recommendations from prior visits have been addressed, propose new
+  follow-up Tasks.
+- **In-chart chat** — a clinician asks "what's this patient's A1c
+  history?"; the agent reads the chart and answers, optionally staging
+  prescriptions or lab orders the clinician then commits.
+- **Background risk stratification** — periodic CronTask emits a
+  `RunAgentEffect`; the agent reviews open patients and creates Tasks
+  for those who match a clinical pattern.
+
+Agents are distinct from handlers because they reason; handlers do
+fixed transformations. Reach for an agent when "what should happen
+next" depends on chart context the rules engine can't enumerate.
+
+## How a run executes
+
+An agent run is asynchronous and driven by the worker, even when the
+trigger is user-initiated (e.g., a chat message). The agent's logic
+runs on the plugin-runner pod, never on the web request thread.
+
+```
+plugin trigger handler        home-app web/worker            plugin-runner pod
+─────────────────────         ──────────────────             ─────────────────
+compute() →
+  RunAgentEffect ─────────→  RunAgentEffectInterpreter
+                               ↓
+                             run_agent Celery task ────→  PluginRunner.RunAgent
+                                                            ↓
+                                                          AgentPlugin.load_state
+                                                          AgentPlugin.run    ← LLM + tools
+                                                          AgentPlugin.save_state
+                                                            ↓
+                             handle_effect ←────────  emitted effects
+```
+
+A trigger emits a `RunAgentEffect`. The home-app interpreter enqueues a
+Celery task. The task makes a gRPC call to the plugin-runner, which
+instantiates your `AgentPlugin` subclass, acquires a per-`scope_key`
+lock, drives `load_state` → `run` → `save_state`, and streams emitted
+effects back to the home-app worker. The worker dispatches each effect
+through the existing `handle_effect` pipeline.
+
+Two invocation patterns share that path:
+
+- **Event-triggered** — a `BaseHandler` in your plugin emits the
+  effect from `compute()` (e.g., on note creation, lab arrival, cron
+  tick).
+- **User-initiated** — a `SimpleAPI` POST handler emits the effect
+  and returns `202 Accepted`; the UI polls a history endpoint until
+  the agent's output lands. Don't run agents synchronously inside a
+  request handler — the plugin-runner iterates handlers sequentially,
+  and a multi-second LLM round-trip blocks every other plugin on the
+  instance.
+
+See [Lifecycle](/sdk/agents-lifecycle/) for what your subclass needs to
+implement and what the platform does around it.
+
+## What the platform owns vs what you own
+
+| Platform owns | You own |
+|---|---|
+| Triggering, dispatch, lifecycle orchestration | Agent business logic (`run()`) |
+| Per-`scope_key` lock + retry on contention | State persistence (Custom Data tables you declare) |
+| LLM credentials + (soon) gateway-mediated billing | Tool implementations |
+| Cost / token / latency metrics | Run rationale and semantic audit (see [Auditing](/sdk/agents-auditing/)) |
+| Effect dispatch | Effect choice + idempotency keying |
+| Tool permission enforcement (manifest-driven) | Tool authorization policy (declared in your manifest) |
+
+You declare an `AgentPlugin` subclass and its tool surface; the
+platform makes sure it runs safely.
+
+## Credentials
+
+For preview, plugin authors configure an Anthropic API key as a plugin
+secret (`ANTHROPIC_API_KEY`, declared in `CANVAS_MANIFEST.json`
+`variables[]`). The customer's admin sets the value on the plugin's
+configuration page. Your `run()` builds an `LLMGateway` from those
+secrets:
+
+```python?partial=true
+from canvas_sdk.agents import LLMGateway
+from anthropic import Anthropic
+
+gateway = LLMGateway.from_plugin_secrets(self.secrets)
+client = Anthropic(api_key=gateway.api_key)
+```
+
+> **Coming soon**: a Canvas-operated LLM gateway. Plugins will receive
+> short-lived session tokens instead of provider keys; per-customer
+> subaccount routing, cost accounting, and audit happen at the gateway
+> boundary. Your `from_plugin_secrets(...)` call site stays unchanged —
+> the gateway returns a session token in `api_key` and the gateway URL
+> in `base_url`.
+
+## Manifest declaration
+
+Each agent goes under `components.agents[]` in your manifest, with the
+tools you authorize it to use:
+
+```jsonc
+{
+  "components": {
+    "agents": [
+      {
+        "class": "my_plugin.agents.chart_summary:ChartSummary",
+        "description": "Drafts a Plan command on the new note",
+        "tools": {
+          "allowed": [
+            "find_medications",
+            "find_conditions",
+            "originate_plan"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+`tools.allowed` is the contract between you, the EHR administrator
+reviewing your plugin, and the runtime. The platform reads it at load
+time and scopes the agent's tool registry before `run()` fires — the
+agent literally cannot see or invoke tools you didn't declare. See
+[Tools](/sdk/agents-tools/) for the full pattern.
+
+## Where to next
+
+<ul>
+  <li><a href="/sdk/agents-quick-start/"><strong>Quick start</strong></a> — minimal working agent in ~50 lines.</li>
+  <li><a href="/sdk/agents-lifecycle/"><strong>Lifecycle</strong></a> — what your subclass implements; the order the runtime calls things.</li>
+  <li><a href="/sdk/agents-managing-state/"><strong>Managing state</strong></a> — three persistence patterns: stateless, snapshot, event-sourced.</li>
+  <li><a href="/sdk/agents-tools/"><strong>Tools</strong></a> — read tools, effect tools, and manifest-driven permissions.</li>
+  <li><a href="/sdk/agents-prompts/"><strong>Prompts</strong></a> — system prompts in a clinical setting.</li>
+  <li><a href="/sdk/agents-testing/"><strong>Testing</strong></a> — patterns for unit-testing agents and tools without real provider calls.</li>
+  <li><a href="/sdk/agents-auditing/"><strong>Auditing</strong></a> — what the platform captures, what you should capture.</li>
+</ul>
+
+<br/>
+<br/>

--- a/collections/_sdk/agents/auditing.md
+++ b/collections/_sdk/agents/auditing.md
@@ -1,0 +1,198 @@
+---
+title: "Auditing"
+slug: "agents-auditing"
+excerpt: "What the platform captures automatically, and what you should capture yourself."
+---
+
+Agent runs need an audit trail for two distinct purposes — billing
+and operations on one side, "what did the agent do, and why" on the
+other. Those two needs have different shapes, different schemas,
+different retention requirements, and different owners. The Agent
+Runner Framework splits the responsibility along that line.
+
+## Platform-owned audit (skeleton)
+
+The platform captures structural facts about every run: things that
+have a stable schema, are needed for billing or abuse detection
+regardless of what the agent author wrote, and have predictable
+retention. You don't need to do anything to enable these — they
+happen automatically for every run.
+
+Captured today:
+
+- **Run lifecycle metadata** — every `RunAgentEffect` produces a
+  durable record with `agent_id`, `scope_key`, `run_id`, status
+  (success / error / locked), start and end timestamps, wall-clock
+  duration.
+- **Lock outcome** — when a run is held off by lock contention,
+  that's recorded so support can see "the third attempt finally
+  acquired the lock at T+38s."
+- **Effect dispatch** — every effect the agent emits passes through
+  `handle_effect`, which carries the run's provenance (`plugin_name`,
+  `classname`, `handler_name`, `actor`, `source`) onto the affected
+  record.
+
+Captured soon (V1 LLM gateway):
+
+- **Per-LLM-call token counts** — input, output, cache reads/writes.
+- **Per-LLM-call cost** — in your customer's currency, against your
+  customer's Anthropic subaccount.
+- **Per-LLM-call latency** — wall-clock and time-to-first-token.
+- **Tool-call envelope** — name, arguments shape/hash, latency,
+  error type for every tool the agent dispatches. Note: the
+  envelope is structural metadata; the tool's *result content* is
+  plugin-owned (see below) because only you know what's worth
+  keeping and what counts as PHI you don't want sitting in
+  platform audit storage.
+
+The skeleton is the safety net. Even if your plugin captured zero
+domain audit data, the platform's records answer: how many times did
+this agent run, what was the success rate, how long did it take, how
+much did it cost. That's enough to investigate basic ops questions
+or notice that an agent is misbehaving. It is *not* enough to answer
+"why did the agent recommend X for this patient" — that's your job.
+
+Retention for platform-captured data is platform-set (long enough
+for billing reconciliation and compliance, with the same
+de-identification and right-to-be-forgotten guarantees that apply to
+other Canvas-held data).
+
+## Plugin-owned audit (semantic)
+
+Why an agent did what it did — and what specifically it looked at to
+decide — is content only you can reason about. Canvas doesn't know
+your agent's intent; the platform can capture the structural facts
+of a run but it can't tell whether the recommendation was a *good*
+recommendation, or whether the agent's tool calls actually informed
+the decision.
+
+You own this layer. Typical things to capture:
+
+- The agent's stated rationale (a natural-language explanation of
+  why it did what it did).
+- The specific chart facts the agent grounded its decision in
+  ("recommended an A1c recheck because last value was 9.2 in March,
+  no recheck since").
+- Tool results that informed the decision, when they're not
+  reconstructable from the patient's current chart state.
+- Inputs from the clinician, for user-initiated agents.
+- The model's final response text, for conversational agents.
+
+These don't have a one-size-fits-all schema — they're agent-specific
+and you should design them around the questions you expect to need
+to answer.
+
+### Recommended pattern
+
+The reference plugin demonstrates one shape: a Custom Data table
+with one row per agent invocation, written by lifecycle hooks:
+
+```python
+class AgentRunLog(CustomModel):
+    """One row per AgentPlugin invocation. Plugin-owned semantic audit."""
+
+    agent_class_name = TextField()
+    scope_key = TextField()
+    status = TextField()                       # "running" | "success" | "error"
+    started_at = DateTimeField(auto_now_add=True)
+    completed_at = DateTimeField(null=True)
+    duration_ms = IntegerField(null=True)
+    llm_turns = IntegerField(null=True)
+    error_type = TextField(blank=True, default="")
+    error_message = TextField(blank=True, default="")
+    # Add the fields your agent's questions actually need:
+    rationale = TextField(blank=True, default="")
+    grounding_facts = JSONField(default=dict)
+```
+
+Hooked up via the lifecycle surface (see
+[Lifecycle](/sdk/agents-lifecycle/)):
+
+```python
+class MyAgent(AgentPlugin):
+    def on_run_start(self, scope_key):
+        self._run_log = AgentRunLog.objects.create(
+            agent_class_name=self.__class__.__name__,
+            scope_key=scope_key,
+            status="running",
+        )
+
+    def on_run_end(self, result):
+        self._run_log.status = "success"
+        self._run_log.completed_at = datetime.now(UTC)
+        # ... other fields ...
+        self._run_log.save()
+
+    def on_run_error(self, exc):
+        self._run_log.status = "error"
+        self._run_log.error_type = type(exc).__name__
+        self._run_log.error_message = str(exc)[:500]
+        self._run_log.save()
+```
+
+Lifecycle hook failures are caught and logged by the platform — a
+broken audit path can't crash the underlying run. See
+[Lifecycle](/sdk/agents-lifecycle/#optional-hooks) for the full
+contract.
+
+## Retention is your decision, with a ceiling
+
+Default retention for Custom Data tables is "as long as the plugin
+is installed." For audit tables, that default is wrong — clinical
+data accumulates indefinitely, your storage bill follows, and
+de-identification / right-to-be-forgotten obligations become
+expensive to honor on data you didn't need to keep.
+
+> **Coming soon**: per-table retention policy declared in
+> `CANVAS_MANIFEST.json` (`components.custom_data[].retention_days`).
+> The platform will run a daily prune job that drops rows older than
+> the declared cutoff. The platform sets a maximum cap by data class
+> (e.g., 2 years for clinical-data-bearing tables, 90 days for purely
+> operational); you choose any duration up to that.
+
+Until then, plan your own retention. Two pragmatic approaches:
+
+1. **Compact aggressively.** Store enough to answer "what happened
+   on this run" for, say, 30 days; compact older runs into per-day
+   aggregates (count, error rate, average duration, p95 cost) and
+   drop the originals.
+2. **Project, then prune.** For "what did the agent decide for this
+   patient" queries, the answer often lives in *clinical state*
+   (a Task, a recommendation, a draft command) not in the audit
+   log itself. Audit-log rows are scaffolding; once their
+   information is reflected in chart state, the audit row can be
+   dropped without losing the decision.
+
+The shape that's almost always wrong: retaining everything forever
+because nobody decided otherwise.
+
+## Evals and replay
+
+> **Coming soon**: SDK helpers for running an agent against captured
+> inputs (the same `trigger_payload` plus the chart state at that
+> moment) to evaluate prompt changes against historical runs.
+
+The minimum you need today for replay is: the agent's
+`trigger_payload`, the patient's chart state at run time (which
+Canvas already retains), and either the prompt + tool definitions
+the agent used or — better — a deterministic pin on the agent class
++ tool registry so you can rebuild them.
+
+The audit-log row + chart state usually gets you there.
+
+## Splitting platform vs plugin in practice
+
+A useful test: if you removed your agent and replaced it with a
+different agent at the same trigger, which audit data would still
+be useful?
+
+- Cost, token counts, run durations, error rates, lock contention
+  — useful regardless of the agent. **Platform-owned.**
+- "The agent saw an A1c of 9.2 and proposed a recheck in 3 months"
+  — only meaningful in the context of this specific agent and its
+  decision logic. **Plugin-owned.**
+
+When in doubt, capture the structural fact in your audit row even
+if you think the platform does too. The platform's records are
+optimized for billing and ops, not for your debugging — and your
+table is closer to where your agent's logic lives.

--- a/collections/_sdk/agents/lifecycle.md
+++ b/collections/_sdk/agents/lifecycle.md
@@ -1,0 +1,200 @@
+---
+title: "Lifecycle"
+slug: "agents-lifecycle"
+excerpt: "What your AgentPlugin subclass implements, and what the platform does around it."
+---
+
+`AgentPlugin` is the abstract base class for every agent. You implement
+three methods (`load_state`, `run`, `save_state`); the platform handles
+dispatch, locking, hook invocation, and effect delivery around them.
+
+```python
+from canvas_sdk.agents import AgentPlugin, AgentRunResult, AgentState, LLMGateway
+
+
+class MyAgent(AgentPlugin):
+
+    def load_state(self, scope_key: str) -> AgentState:
+        """Return this run's starting state, or AgentState() if none."""
+        ...
+
+    def run(
+        self,
+        state: AgentState,
+        gateway: LLMGateway,
+        trigger_payload: dict,
+    ) -> AgentRunResult:
+        """Drive the agent. Return updated state and the effects to emit."""
+        ...
+
+    def save_state(self, scope_key: str, state: AgentState) -> None:
+        """Persist the updated state for the next run."""
+        ...
+```
+
+## What the platform does, in order
+
+When a `RunAgentEffect` reaches the plugin-runner's `RunAgent` RPC, the
+following happens — each step is platform-driven, all inside the
+per-`scope_key` lock:
+
+1. **Resolve the agent class** from `LOADED_PLUGINS` by `agent_id`.
+2. **Build the `LLMGateway`** from the plugin's secrets dict via
+   `LLMGateway.from_plugin_secrets(plugin.secrets)`.
+3. **Acquire the per-`scope_key` lock**. If another invocation holds
+   it, the run returns `success=False` with `error_kind="AGENT_LOCKED"`;
+   the Celery task auto-retries with exponential backoff. See
+   [Concurrency](#concurrency) below.
+4. **Instantiate your subclass** (`agent_class()` with no arguments).
+5. **Inject the manifest tool allowlist** as
+   `agent.tools_allowed = frozenset(manifest_allowed)` and replace
+   `agent.tools` with a scoped view containing only those tools.
+6. **Call `on_run_start(scope_key)`** (optional hook; default no-op).
+7. **Call `load_state(scope_key)`** to get the run's starting state.
+8. **Call `run(state, gateway, trigger_payload)`** — the body of your
+   agent.
+9. **Call `save_state(scope_key, result.state)`** with the updated
+   state from your `AgentRunResult`.
+10. **Call `on_run_end(result)`** (optional hook).
+11. **Release the lock.**
+12. **Stamp provenance on each emitted effect** (`plugin_name`,
+    `classname`, `handler_name`, `actor`, `source`) and stream them
+    back to the home-app worker for dispatch through
+    `handle_effect`.
+
+If any of steps 7–9 raises, `on_run_error(exc)` fires, the exception
+is captured to Sentry, and the run returns `success=False`.
+
+## The three methods you implement
+
+### `load_state(scope_key) -> AgentState`
+
+Called once per run, before `run()`. Return the state this run should
+start from — read from your Custom Data tables, deserialize a JSON
+blob, query the chart, whatever makes sense. Return `AgentState()`
+(empty) if your agent is stateless.
+
+`scope_key` is the same string the trigger emitted; you control its
+shape. Use it as the key into your storage.
+
+### `run(state, gateway, trigger_payload) -> AgentRunResult`
+
+The body of your agent. Drive the tool-use loop, accumulate effects,
+update `state` in place. Return an `AgentRunResult(state=..., effects=[...])`.
+
+```python
+def run(self, state, gateway, trigger_payload):
+    effects: list[Effect] = []
+    tool_ctx = {"patient_id": trigger_payload["patient_id"], "effects": effects}
+    # ... LLM loop using self.tools ...
+    return AgentRunResult(state=state, effects=effects)
+```
+
+The `effects` list is what the platform will dispatch *after* `run()`
+returns and `save_state()` commits — the platform owns *when* effects
+emit; your agent owns *what*. This split keeps idempotency clean:
+because save and dispatch are both bracketed by the lock, a retry
+sees the same starting state, decides the same effects, and the
+platform can apply dedup if it's seen the run before.
+
+### `save_state(scope_key, state) -> None`
+
+Called once per run, after `run()` returns. Persist `state.data`
+back to wherever you read it from. For stateless agents this is a
+no-op.
+
+`save_state` runs **inside the lock**. A concurrent `RunAgentEffect`
+for the same `scope_key` is held off until you return.
+
+## Optional hooks
+
+`AgentPlugin` declares four lifecycle hooks. Override them in your
+subclass to capture observability data without polluting `run()`.
+
+| Hook | When it fires | What it receives |
+|---|---|---|
+| `on_run_start(scope_key)` | After instantiation, before `load_state` | The scope_key for this run |
+| `on_run_end(result)` | After `save_state` succeeds | The `AgentRunResult` |
+| `on_run_error(exc)` | If any of `load_state` / `run` / `save_state` raises | The exception |
+| `on_turn(turn_index)` | Per-turn (not wired in preview — coming soon) | The turn number |
+
+```python
+def on_run_start(self, scope_key):
+    self._started = time.perf_counter()
+
+def on_run_end(self, result):
+    duration_ms = int((time.perf_counter() - self._started) * 1000)
+    MyAuditLog.objects.create(scope_key=scope_key, duration_ms=duration_ms, status="ok")
+
+def on_run_error(self, exc):
+    MyAuditLog.objects.create(scope_key=scope_key, status="error", error=type(exc).__name__)
+```
+
+Hook failures are caught and logged by the platform — a broken
+observability path can't crash the underlying run.
+
+See [Auditing](/sdk/agents-auditing/) for the recommended split
+between platform-owned and plugin-owned audit data.
+
+## Concurrency
+
+The platform serializes invocations per-`scope_key`. Two
+`RunAgentEffect`s with the same `scope_key` cannot run at the same
+time; the second is held off until the first completes (lock + retry
+with exponential backoff).
+
+This lets `load_state` / `run` / `save_state` treat the underlying
+storage as if no one else is touching it during the run.
+
+**Picking a `scope_key`**: encode whatever should serialize. Common
+shapes:
+
+```python
+# Patient-scoped — two runs on the same patient serialize.
+f"my_plugin:chart_summary:patient:{patient_id}"
+
+# Patient-and-encounter-scoped — runs on the same encounter serialize,
+# but the same patient on different encounters can run concurrently.
+f"my_plugin:visit_summary:encounter:{encounter_id}"
+
+# Tenant-wide — only one run anywhere at a time. Useful for cron jobs
+# you want strictly serialized.
+"my_plugin:nightly_review"
+```
+
+Tenant isolation is automatic (the lock storage prefixes keys with
+the customer identifier), so you don't need to namespace by customer.
+
+## The `AgentRunResult` shape
+
+```python
+@dataclass
+class AgentRunResult:
+    state: AgentState
+    effects: list[Effect]
+```
+
+`state` is what `save_state` will persist. `effects` is what the
+platform will dispatch.
+
+## `LLMGateway` shape
+
+```python
+@dataclass
+class LLMGateway:
+    api_key: str
+    model: str
+    base_url: str | None = None
+```
+
+Built by the platform from the plugin's `secrets` dict via
+`LLMGateway.from_plugin_secrets(...)` before `run()` is called. Defaults
+to reading `ANTHROPIC_API_KEY` and `ANTHROPIC_MODEL`. Raises
+`LLMGatewayConfigurationError` if the key is missing — the platform
+catches this and reports the run as failed without entering your
+`run()`.
+
+> **Coming soon**: with the Canvas LLM gateway, `api_key` becomes a
+> short-lived session token and `base_url` points at the gateway
+> service. Your code (`Anthropic(api_key=gateway.api_key)`) doesn't
+> change — only the underlying credential lifecycle does.

--- a/collections/_sdk/agents/managing-state.md
+++ b/collections/_sdk/agents/managing-state.md
@@ -1,0 +1,226 @@
+---
+title: "Managing State"
+slug: "agents-managing-state"
+excerpt: "Three patterns for persisting agent state across runs."
+---
+
+`AgentState` itself is intentionally thin — it's a dataclass holding a
+`data: dict[str, Any]` that the framework hands to `run()` and
+collects back from it. The interesting decision is *what* you store
+and *where*, and the answer depends on what your agent actually needs
+to remember.
+
+Three patterns cover the common cases. They share the same
+`load_state` / `run` / `save_state` contract — only what those methods
+do differs.
+
+## Pattern 1: Stateless
+
+The agent has no memory of prior runs. Every invocation reads the
+patient's current chart fresh, makes a decision, emits effects. This
+is the simplest pattern and the right starting point.
+
+```python
+class ChartSummary(AgentPlugin):
+    """Drafts a Plan command on a new note. No state between runs."""
+
+    def load_state(self, scope_key):
+        return AgentState()
+
+    def run(self, state, gateway, trigger_payload):
+        # ... LLM loop, accumulate effects ...
+        return AgentRunResult(state=state, effects=effects)
+
+    def save_state(self, scope_key, state):
+        return None
+```
+
+Use it when each run can stand on its own — the trigger fires, the
+agent reads the chart, the agent emits effects, done.
+
+## Pattern 2: Snapshot
+
+The whole state lives in one record. `load_state` reads it,
+`run()` mutates it in memory, `save_state` writes it back. Best for
+agents whose state grows roughly linearly in time and is always read
+as a unit — chat conversations being the canonical example.
+
+The full message history (user turns + assistant turns + tool calls +
+tool results) lives in a single JSON column. Reading the row and
+writing it back is one round-trip each.
+
+```python
+from django.db.models import DO_NOTHING, ForeignKey, JSONField
+from canvas_sdk.v1.data.base import CustomModel
+
+
+class Conversation(CustomModel):
+    """One row per patient, holds the full message history as JSON."""
+
+    patient = ForeignKey(PatientProxy, to_field="dbid", on_delete=DO_NOTHING)
+    messages = JSONField(default=list)
+
+
+class ChatAgent(AgentPlugin):
+    tools = _registered_tools
+
+    def load_state(self, scope_key):
+        patient_id = scope_key.rsplit(":", 1)[-1]
+        conversation = Conversation.objects.filter(patient__id=patient_id).first()
+        return AgentState(data={
+            "patient_id": patient_id,
+            "messages": list(conversation.messages) if conversation else [],
+        })
+
+    def run(self, state, gateway, trigger_payload):
+        messages = state.data["messages"]
+        messages.append({"role": "user", "content": trigger_payload["user_message"]})
+        # ... LLM loop appends assistant turns + tool blocks to messages ...
+        state.data["messages"] = messages
+        return AgentRunResult(state=state, effects=[])
+
+    def save_state(self, scope_key, state):
+        patient = PatientProxy.objects.get(id=state.data["patient_id"])
+        conversation, _ = Conversation.objects.get_or_create(patient=patient)
+        conversation.messages = state.data["messages"]
+        conversation.save()
+```
+
+The platform's per-`scope_key` lock guarantees that `load → run →
+save` is atomic — no race between two concurrent runs reading the
+same baseline and clobbering each other.
+
+**Trade-offs**: read and write cost grow with history length. At some
+point (typically dozens-of-turns) you'll want to either trim the
+in-memory list before sending it to the LLM (to control prompt
+tokens) or compact it into a summary. For chat in particular, plan
+for that compaction before the conversation grows unbounded.
+
+The snapshot pattern is also where **prompt caching** pays off most
+— the system prompt, tool definitions, and the prefix of the message
+history are stable turn-to-turn. See [Prompts → Prompt caching for
+cost control](/sdk/agents-prompts/#prompt-caching-for-cost-control).
+
+> **Coming soon**: the SDK will ship `AllTurnsState`,
+> `SlidingWindowState`, and `SummarizingState` helpers that handle
+> the load/save plumbing for the common snapshot shapes (full
+> history, last-N turns only, periodically summarized). Until then,
+> the snapshot pattern is something you implement yourself per agent
+> — the example above is the typical shape.
+
+## Pattern 3: Event-sourced
+
+State is a set of rows, each a discrete fact. `load_state` rarely
+reads them (the agent queries them inside `run()` instead);
+`save_state` is often a no-op because writes happen as a side
+effect of tool calls during the run.
+
+Best for agents whose state is "a list of things we've recommended
+over time" or "a log of decisions, indexed for later lookup." Each
+recommendation is its own row; you can mark them resolved
+independently, query just the open ones, count them, etc. — all
+things that are awkward with the snapshot pattern.
+
+```python
+class Recommendation(CustomModel):
+    """One row per recommendation the agent has proposed."""
+
+    patient = ForeignKey(PatientProxy, to_field="dbid", on_delete=DO_NOTHING)
+    narrative = TextField()
+    category = TextField()         # "task" | "follow_up_lab" | "none"
+    status = TextField(default="open")  # "open" | "addressed" | "obsolete"
+    proxy_data = JSONField(default=dict)
+
+
+@tools.tool(name="propose_recommendation", description="...", input_schema={...})
+def _propose_recommendation(arguments, *, ctx):
+    """Write one Recommendation row + stage an AddTask effect to surface it."""
+    patient = PatientProxy.objects.get(id=ctx["patient_id"])
+    rec = Recommendation.objects.create(
+        patient=patient,
+        narrative=arguments["narrative"],
+        category=arguments["category"],
+        proxy_data=arguments.get("proxy_data") or {},
+    )
+    ctx["effects"].append(AddTask(patient_id=ctx["patient_id"], title=rec.narrative).apply())
+    return {"ok": True, "recommendation_id": str(rec.id)}
+
+
+class LongitudinalAdvisor(AgentPlugin):
+    tools = _registered_tools
+
+    def load_state(self, scope_key):
+        # Don't materialize state here — run() queries the table directly.
+        return AgentState()
+
+    def run(self, state, gateway, trigger_payload):
+        patient_id = trigger_payload["patient_id"]
+        open_recs = Recommendation.objects.filter(patient__id=patient_id, status="open")
+        # ... agent reasons over open recommendations + chart context ...
+        return AgentRunResult(state=state, effects=effects)
+
+    def save_state(self, scope_key, state):
+        return None  # writes happen inside tool calls
+```
+
+**Trade-offs**: writes are scattered through `run()` (via tool calls)
+rather than gathered in `save_state`. That means a crash mid-run can
+leave partial state — some recommendations written, others not.
+Acceptable for most cases because the "missing" recommendations
+simply re-propose on the next trigger. Less acceptable if writes need
+to be transactional with effect emission, in which case prefer the
+snapshot pattern.
+
+This pattern works especially well when **the rows are queryable for
+their own purposes** — clinicians' task queues, admin reporting,
+metrics dashboards. The agent's writes become first-class chart data,
+not just agent-internal scaffolding.
+
+## Picking a pattern
+
+| Pattern | When |
+|---|---|
+| Stateless | Each run can stand alone; no learning across runs. |
+| Snapshot | One coherent thing grows over time (a conversation, a session). |
+| Event-sourced | A set of discrete facts that need to be queried, counted, or updated independently. |
+
+You can mix patterns within a plugin — different agents have different
+needs.
+
+## `AgentState` mechanics
+
+```python
+@dataclass
+class AgentState:
+    data: dict[str, Any] = field(default_factory=dict)
+```
+
+The dict is yours to shape. Keep it JSON-serializable if you plan to
+hand-roll storage that uses `JSONField`; otherwise any structure that
+your `save_state` can persist is fine.
+
+The state is held *only* across the boundary between `load_state` and
+`save_state` — it's not implicit on `self`. (Hooks like
+`on_run_start` and `on_run_end` see the agent instance but should
+treat instance state as ephemeral; the run might be re-instantiated
+on a different worker on retry.)
+
+## Storage options
+
+State has to live somewhere the next run can find it. Three durable
+options the SDK supports:
+
+- **[Custom Data](/sdk/custom-data/) tables** (recommended for
+  durable state). Your plugin declares `CustomModel` subclasses in
+  its manifest; rows persist across plugin reloads. Both
+  patterns 2 and 3 above use this.
+- **[Caching API](/sdk/caching/)** (TTL-bounded; up to 14 days). Best
+  for ephemeral state that's recoverable if lost — partial
+  computation results, recently-seen tokens, etc.
+- **External services** (`canvas_sdk.clients`). Plugin secrets carry
+  credentials; do your own I/O. Common for integrations that need
+  cross-instance state.
+
+Reach for Custom Data first. The platform indexes it the same way as
+core models, plays nicely with the per-`scope_key` lock, and shows up
+in your plugin's namespace so it's easy to reason about retention.

--- a/collections/_sdk/agents/prompts.md
+++ b/collections/_sdk/agents/prompts.md
@@ -1,0 +1,218 @@
+---
+title: "Prompts"
+slug: "agents-prompts"
+excerpt: "System and in-dialogue prompt patterns for clinical agents."
+---
+
+The system prompt is where you set boundaries the model can't be
+talked out of: the agent's role, what it's allowed to do, what
+counts as a successful completion, the format of its output. The
+in-dialogue prompt — the first `{"role": "user", "content": "..."}`
+message — is where you frame the specific task this run is for.
+
+Both matter, but they do different jobs.
+
+## System prompt
+
+The system prompt is constant across turns; the model anchors on it
+heavily. Use it for things that should always be true regardless of
+what the conversation drifts into.
+
+What to put in it:
+
+- **The role.** "You are a clinical documentation assistant
+  drafting..." — not "You are an AI." Be specific about the
+  clinical context.
+- **The available tools and when to use them.** The model already
+  sees tool definitions, but a sentence in the prompt about how
+  *you* want them used helps. "Read the chart with the read tools,
+  then call `originate_plan` exactly once."
+- **Hard boundaries.** What the agent must NOT do, framed as
+  policy. "You never commit commands; you only originate drafts
+  for the clinician to review." "Use the write tools only when
+  the clinician explicitly asks; for discussion or summary, stay
+  read-only."
+- **Output format.** "Plain text only — no markdown headings." "≤
+  3 sentences." Be explicit. The model defaults to a lot of
+  markdown otherwise.
+- **Termination criterion.** "After the tool returns, you may end
+  your turn — no further text is required." Some models hold the
+  turn open waiting for clarification; tell them not to.
+
+What to leave out:
+
+- **PHI**. The system prompt is reused across runs; it shouldn't
+  carry patient-specific information. That belongs in the in-
+  dialogue prompt or as tool results.
+- **Generic safety boilerplate**. The model already knows it
+  shouldn't recommend self-harm. Phrases like "be safe and ethical"
+  do nothing and use up your prompt budget. Mention only
+  domain-specific boundaries Canvas's clinical context demands.
+- **Long examples**. One short example helps; a fixture-style few-
+  shot block usually hurts. The system prompt's job is to set rules,
+  not to teach by demonstration.
+
+Example from the reference plugin's chart summary agent:
+
+```python
+SYSTEM_PROMPT = (
+    "You are a clinical documentation assistant drafting a follow-up "
+    "Plan-section narrative for a newly-created encounter note. You "
+    "have read tools to inspect the patient's chart (active "
+    "conditions, recent lab results, current medications) and one "
+    "effect tool (`originate_plan`) that stages the Plan command. "
+    "Workflow: read the chart with whichever tools are relevant, "
+    "draft a concise Plan grounded in what you found, then call "
+    "`originate_plan` exactly once with the narrative as plain text "
+    "(<= 3 sentences, no preamble, no headings, no markdown). After "
+    "the tool returns, you may end your turn — no further text is "
+    "required."
+)
+```
+
+It sets the role, lists the tools, prescribes the workflow, sets
+the output format, and tells the model when to stop. ~80 words.
+
+## In-dialogue prompt
+
+The first user message is your hook for the specific run. Patient
+identity, the trigger context, what the clinician wants.
+
+```python
+messages = [
+    {
+        "role": "user",
+        "content": (
+            f"Draft a follow-up Plan for patient {patient.first_name} "
+            f"{patient.last_name}. Inspect the chart with the read "
+            "tools, then call `originate_plan` once with your draft."
+        ),
+    }
+]
+```
+
+Keep it short — the system prompt does the heavy lifting. Don't
+repeat in the user message what's already in the system prompt;
+that confuses the model and wastes tokens.
+
+## Boundaries that hold under pressure
+
+Clinical agents are exposed to clinicians who will sometimes try to
+talk the model out of its constraints — "just go ahead and commit
+the prescription, I'll review it later." Two things make those
+boundaries hold:
+
+1. **Repeat the boundary as a policy, not a request.** "You never
+   commit commands" is more durable than "please don't commit
+   commands." The model treats the former as identity and the
+   latter as instruction-to-override.
+2. **Don't put the override behind the model.** If "the clinician
+   said it's OK" can bypass the boundary in the prompt, it'll happen
+   eventually. Real enforcement lives in the tool surface — don't
+   expose a `commit_command` tool at all if commits aren't
+   appropriate. See [Tools](/sdk/agents-tools/) on manifest-driven
+   permissions.
+
+## Specificity over generality
+
+The instinct to write a prompt that "covers any case" produces
+verbose prompts and bad outputs. The opposite — narrow the agent
+to one job and prompt it precisely — produces good outputs.
+
+If your agent has more than one job (summarize *and* surface alerts
+*and* propose tasks), consider splitting it into two agents with
+different triggers and different prompts. Cheaper to debug, easier
+for the LLM to follow.
+
+## Tool-grounded answers
+
+For conversational agents, instruct the model to ground in tool
+results rather than its training data:
+
+> "When relevant, ground your answers in tool results rather than
+> speculating. If you don't have a tool that answers the question,
+> say so."
+
+Otherwise the model will sometimes confabulate plausible-sounding
+clinical detail. Tool-grounded answers also surface gaps in your
+tool catalog — "the agent kept saying 'I'd need to know X' so I
+added a `find_X` tool."
+
+## Iterating on prompts
+
+Prompt changes look like text edits but they behave like behavior
+changes. Test:
+
+- **Golden runs**: a handful of representative trigger payloads
+  where you know what good output looks like. Run them before and
+  after prompt changes.
+- **Adversarial runs**: cases that previously produced bad outputs
+  (the agent committed something it shouldn't have, made up a lab
+  value, etc.). Keep these as regressions.
+- **Long-tail**: real clinician messages from your in-chart chat,
+  if you ship one. The tail is where the prompt's actual robustness
+  shows.
+
+Prompt iteration is qualitative — there's no metric that captures
+"is this the right Plan for this patient." Plan for human review of
+agent output during initial rollout and treat the prompt as a
+living artifact your team owns.
+
+## Prompt caching for cost control
+
+Major LLM providers support **prompt caching** — marking a stable
+prefix of the prompt as cacheable so subsequent calls within the cache
+TTL pay a fraction of the token cost on the cached portion. The
+mechanics differ between providers (Anthropic uses explicit
+block-level markers; OpenAI caches eligible prefixes automatically;
+Gemini uses a separate `CachedContent` resource), so what follows is
+specifically Anthropic's `cache_control` flag.
+
+The stable parts of a typical agent call are the system prompt and
+the tool definitions. For chat-shaped agents, most of the message
+history is also stable turn-to-turn (only the last user message and
+the new assistant turn change). Mark a cache breakpoint on the last
+block of the stable prefix:
+
+```python
+client.messages.create(
+    model=gateway.model,
+    system=[
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ],
+    tools=self.tools.definitions(),
+    messages=messages,
+)
+```
+
+That marks the system prompt as cacheable; the next call within
+~5 minutes that shares the same system text pays only the
+cached-read rate on those tokens. For more aggressive caching you
+can mark the last tool definition and a position in the message
+history as additional breakpoints — see [Anthropic's prompt caching
+docs](https://docs.claude.com/en/docs/build-with-claude/prompt-caching)
+for current TTLs, eligibility, pricing, and breakpoint limits.
+
+**Where the win actually lands:**
+
+- **Chat-shaped agents** see large savings. The system prompt + tool
+  catalog + most of the history are stable across turns within a
+  conversation; cache hits compound.
+- **Tool-use loops within a single run** also benefit — the system
+  prompt and tools are constant across the loop iterations, so each
+  subsequent turn's prefix tokens come from cache.
+- **Triggered agents that fire infrequently** (note creation, lab
+  arrival, nightly cron) probably won't see meaningful hits. The
+  5-minute TTL expires between most invocations. Adding
+  `cache_control` markers to these agents costs nothing but won't
+  save much either.
+
+> **Coming soon**: when the Canvas LLM gateway lands, prompt-caching
+> policy will likely be applied per-plugin at the gateway boundary —
+> plugin authors will declare cache breakpoints once (or accept a
+> reasonable default) and not need to thread `cache_control` through
+> every call site. Until then, opt in explicitly where it matters.

--- a/collections/_sdk/agents/quick-start.md
+++ b/collections/_sdk/agents/quick-start.md
@@ -1,0 +1,287 @@
+---
+title: "Quick Start"
+slug: "agents-quick-start"
+excerpt: "Build a minimal agent that drafts a Plan command on note creation."
+---
+
+This walks through the smallest possible agent — a triggered, stateless
+one that reads the chart on note creation and drafts a Plan command for
+the clinician to edit and commit. ~50 lines of agent code, plus a
+manifest entry and a trigger handler.
+
+## 1. Configure the plugin secret
+
+Your manifest declares the Anthropic API key as a plugin variable; the
+customer's admin sets the value once the plugin is installed.
+
+`CANVAS_MANIFEST.json`:
+
+```jsonc
+{
+  "variables": [
+    {"name": "ANTHROPIC_API_KEY", "sensitive": true},
+    {"name": "ANTHROPIC_MODEL", "sensitive": false}
+  ]
+}
+```
+
+`ANTHROPIC_MODEL` is optional; the SDK defaults to `claude-sonnet-4-6`.
+
+## 2. Register a tool catalog
+
+Tools are pre-declared at module-import time and registered into a
+`ToolRegistry`. Start with the SDK's `standard_tools` (clinical reads
+with patient-scope built in) and layer your own.
+
+`chart_summary_tools.py`:
+
+```python
+from canvas_sdk.agents import ToolRegistry, standard_tools
+from canvas_sdk.commands import PlanCommand
+
+tools = ToolRegistry()
+tools.extend(standard_tools)  # find_medications, find_conditions, etc.
+
+
+@tools.tool(
+    name="originate_plan",
+    description=(
+        "Stage a Plan command on the patient's current note. Call this "
+        "exactly once with the narrative as plain text — no preamble, "
+        "no headings, no markdown, <= 3 sentences."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "narrative": {"type": "string"},
+        },
+        "required": ["narrative"],
+    },
+)
+def _originate_plan(arguments, *, ctx):
+    """Stage a draft Plan command into the agent's effects accumulator."""
+    effects = ctx["effects"]
+    note_id = ctx["note_id"]
+    narrative = arguments["narrative"].strip()
+    effects.append(PlanCommand(note_uuid=note_id, narrative=narrative).originate())
+    return {"ok": True}
+```
+
+See [Tools](/sdk/agents-tools/) for the full registry / executor /
+permission model.
+
+## 3. Implement the agent
+
+`chart_summary.py`:
+
+```python
+from typing import Any, cast
+
+from anthropic import Anthropic
+from anthropic.types import ToolUseBlock
+
+from my_plugin.agents.chart_summary_tools import tools as _registered_tools
+from canvas_sdk.agents import AgentPlugin, AgentRunResult, AgentState, LLMGateway
+from canvas_sdk.effects import Effect
+from canvas_sdk.v1.data import Patient
+
+SYSTEM_PROMPT = (
+    "You are a clinical documentation assistant drafting a follow-up "
+    "Plan-section narrative for a newly-created encounter note. You "
+    "have read tools to inspect the patient's chart. Read the chart, "
+    "draft a concise Plan grounded in what you found, then call "
+    "`originate_plan` exactly once with the narrative as plain text "
+    "(<= 3 sentences, no preamble, no headings, no markdown)."
+)
+
+MAX_TURNS = 8
+
+
+class ChartSummary(AgentPlugin):
+    """Drafts a Plan command for a new note via tool-driven chart reads."""
+
+    # The platform scopes this to the manifest's tools.allowed before
+    # run() fires. Always use `self.tools`, not the imported `_registered_tools`.
+    tools = _registered_tools
+
+    def load_state(self, scope_key: str) -> AgentState:
+        """Stateless agent — no prior state to load."""
+        return AgentState()
+
+    def run(
+        self,
+        state: AgentState,
+        gateway: LLMGateway,
+        trigger_payload: dict[str, Any],
+    ) -> AgentRunResult:
+        patient_id = trigger_payload["patient_id"]
+        note_id = trigger_payload["note_id"]
+        patient = Patient.objects.get(id=patient_id)
+
+        # Effects accumulator + per-run context for tools.
+        effects: list[Effect] = []
+        tool_ctx = {"patient_id": patient_id, "note_id": note_id, "effects": effects}
+
+        client = Anthropic(api_key=gateway.api_key)
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": (
+                    f"Draft a follow-up Plan for {patient.first_name} "
+                    f"{patient.last_name}. Inspect the chart with the "
+                    "read tools, then call `originate_plan` once."
+                ),
+            }
+        ]
+
+        for _ in range(MAX_TURNS):
+            response = client.messages.create(
+                model=gateway.model,
+                max_tokens=1024,
+                system=SYSTEM_PROMPT,
+                tools=cast(Any, self.tools.definitions()),
+                messages=cast(Any, messages),
+            )
+            messages.append({"role": "assistant", "content": response.content})
+
+            if response.stop_reason == "end_turn":
+                break
+
+            if response.stop_reason == "tool_use":
+                tool_results = []
+                for block in response.content:
+                    if not isinstance(block, ToolUseBlock):
+                        continue
+                    try:
+                        result = self.tools.execute(
+                            block.name, dict(block.input), ctx=tool_ctx
+                        )
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": str(result),
+                        })
+                    except Exception as exc:
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": f"Tool failed: {exc}",
+                            "is_error": True,
+                        })
+                messages.append({"role": "user", "content": tool_results})
+                continue
+
+            break
+
+        return AgentRunResult(state=state, effects=effects)
+
+    def save_state(self, scope_key: str, state: AgentState) -> None:
+        """Stateless — nothing to persist."""
+        return None
+```
+
+The `AgentPlugin` contract is three methods: `load_state`, `run`, and
+`save_state`. For this stateless agent both `load_state` and
+`save_state` are no-ops. The `run()` method drives the tool-use loop
+and accumulates effects.
+
+## 4. Trigger the agent
+
+Agents don't subscribe to events directly. A regular handler does, and
+emits a `RunAgentEffect` from `compute()`.
+
+`triggers.py`:
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.agent import RunAgentEffect
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers.base import BaseHandler
+from canvas_sdk.v1.data.note import CurrentNoteStateEvent, NoteStates
+
+
+class ChartSummaryTrigger(BaseHandler):
+    """Fires the ChartSummary agent when a note is created."""
+
+    RESPONDS_TO = [EventType.Name(EventType.NOTE_STATE_CHANGE_EVENT_CREATED)]
+
+    def compute(self) -> list[Effect]:
+        # Only fire on note creation (NEW state).
+        state = CurrentNoteStateEvent.objects.values_list("state", flat=True).get(
+            id=self.event.target.id
+        )
+        if state != NoteStates.NEW:
+            return []
+
+        note_id = self.context.get("note_id")
+        patient_id = self.context.get("patient_id")
+        if not (note_id and patient_id):
+            return []
+
+        return [
+            RunAgentEffect(
+                agent_id="my_plugin.agents.chart_summary:ChartSummary",
+                scope_key=f"my_plugin:chart_summary:patient:{patient_id}",
+                trigger_payload={"patient_id": patient_id, "note_id": note_id},
+            ).apply()
+        ]
+```
+
+`agent_id` is the colon-separated module path + class name.
+`scope_key` is yours to shape — by convention, prefix with plugin name
+and agent identity so two agents on the same patient don't serialize
+against each other. The platform uses it as the lock key.
+
+## 5. Wire it up in the manifest
+
+```jsonc
+{
+  "components": {
+    "handlers": [
+      {
+        "class": "my_plugin.triggers:ChartSummaryTrigger",
+        "description": "Emits RunAgentEffect on note creation"
+      }
+    ],
+    "agents": [
+      {
+        "class": "my_plugin.agents.chart_summary:ChartSummary",
+        "description": "Drafts a Plan command on the new note",
+        "tools": {
+          "allowed": [
+            "find_medications",
+            "find_conditions",
+            "find_lab_results",
+            "get_patient_demographics",
+            "originate_plan"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+The `tools.allowed` list authorizes specific tools by name. The
+platform reads this and scopes `self.tools` at run time — see
+[Tools](/sdk/agents-tools/).
+
+## 6. Install + test
+
+```bash
+canvas install my_plugin --host <your-instance>
+```
+
+Configure `ANTHROPIC_API_KEY` on the plugin's admin page, then create a
+new note in the chart. Within a few seconds the agent should run on
+the worker, call the chart-read tools, and stage a draft Plan command
+on the new note.
+
+## Next steps
+
+- [Lifecycle](/sdk/agents-lifecycle/) — what the platform calls on
+  your subclass and in what order.
+- [Managing state](/sdk/agents-managing-state/) — for agents that
+  need to remember things across runs.
+- [Tools](/sdk/agents-tools/) — designing your own read and effect tools.
+- [Prompts](/sdk/agents-prompts/) — system-prompt patterns for clinical agents.

--- a/collections/_sdk/agents/testing.md
+++ b/collections/_sdk/agents/testing.md
@@ -1,0 +1,309 @@
+---
+title: "Testing"
+slug: "agents-testing"
+excerpt: "Patterns for testing AgentPlugin subclasses, tools, and the LLM loop without making real provider calls."
+---
+
+`AgentPlugin` is a regular Python class — `load_state`, `run`, and
+`save_state` are testable directly, without spinning up the
+plugin-runner harness. The only real friction is that `run()`
+typically calls Anthropic, which you don't want firing in your unit
+tests. Stub the LLM client and your agent becomes deterministically
+testable.
+
+This page assumes you have the general SDK testing setup from
+[Testing Utilities](/sdk/testing-utils/). The patterns below build on
+that.
+
+## Test the executor of each tool first
+
+Tool executors are pure functions: `fn(arguments, *, ctx) -> Any`.
+They're the easiest part of an agent to test, and the most worth
+testing because the executor is where your business logic lives.
+
+```python
+from my_plugin.agents.chart_summary_tools import (
+    _originate_plan,
+    _list_active_conditions,
+)
+
+
+def test_originate_plan_appends_effect_to_accumulator():
+    """The tool stages a Plan command effect and returns ok."""
+    effects = []
+    ctx = {"patient_id": "p1", "note_id": "n1", "effects": effects}
+
+    result = _originate_plan({"narrative": "Recheck A1c in 3 months"}, ctx=ctx)
+
+    assert result == {"ok": True}
+    assert len(effects) == 1
+    # The effect is what the platform will dispatch after run() returns.
+
+
+def test_list_active_conditions_filters_to_patient(patient_factory, condition_factory):
+    """Tool reads are patient-scoped via ctx — model arguments can't widen."""
+    target = patient_factory()
+    other = patient_factory()
+    condition_factory(patient=target, code="E11.9", display="Type 2 diabetes")
+    condition_factory(patient=other, code="I10", display="Hypertension")
+
+    result = _list_active_conditions({}, ctx={"patient_id": target.id})
+
+    codes = {c["code"] for c in result}
+    assert codes == {"E11.9"}
+```
+
+The second test uses `factory_boy`-style fixtures from
+`canvas[test-utils]` (see [Testing Utilities](/sdk/testing-utils/)).
+Tool tests against real data are the most valuable layer — they
+catch ORM-level bugs (wrong filter, wrong relation traversal) that
+mocked-data tests miss.
+
+## Stubbing the `LLMGateway`
+
+Inside `run()`, your agent instantiates an Anthropic client from
+`gateway.api_key`. Replace the client in tests so no real provider
+call happens.
+
+```python
+from unittest.mock import patch, MagicMock
+
+import pytest
+from anthropic.types import TextBlock, ToolUseBlock
+
+from canvas_sdk.agents import AgentState, LLMGateway
+from my_plugin.agents.chart_summary import ChartSummary
+
+
+@pytest.fixture
+def gateway():
+    """A fake gateway that satisfies the dataclass without exercising HTTP."""
+    return LLMGateway(api_key="sk-fake", model="claude-sonnet-4-6")
+
+
+def _response(*, content, stop_reason):
+    """Build a minimal Anthropic-shaped response object for the loop to consume."""
+    response = MagicMock()
+    response.content = content
+    response.stop_reason = stop_reason
+    return response
+
+
+def _tool_use(name, input_dict, *, block_id="tu_1"):
+    block = MagicMock(spec=ToolUseBlock)
+    block.type = "tool_use"
+    block.id = block_id
+    block.name = name
+    block.input = input_dict
+    return block
+
+
+def _text(text):
+    block = MagicMock(spec=TextBlock)
+    block.type = "text"
+    block.text = text
+    return block
+```
+
+These three helpers (`_response`, `_tool_use`, `_text`) are typically
+the only LLM-mocking infrastructure you need.
+
+## Driving the run loop in tests
+
+The pattern: queue the responses you want the mock Anthropic client
+to return, then drive `run()` and assert on the result.
+
+```python
+@patch("my_plugin.agents.chart_summary.Anthropic")
+def test_run_drafts_plan_from_tool_results(
+    mock_anthropic_cls, gateway, patient_factory
+):
+    """Two-turn run: agent calls a read tool, then originates the Plan."""
+    patient = patient_factory()
+    mock_client = MagicMock()
+    mock_anthropic_cls.return_value = mock_client
+
+    # Turn 1: model calls find_conditions.
+    # Turn 2: model calls originate_plan with a narrative, then ends.
+    mock_client.messages.create.side_effect = [
+        _response(
+            content=[_tool_use("find_conditions", {}, block_id="tu_1")],
+            stop_reason="tool_use",
+        ),
+        _response(
+            content=[
+                _tool_use(
+                    "originate_plan",
+                    {"narrative": "Recheck A1c in 3 months."},
+                    block_id="tu_2",
+                ),
+            ],
+            stop_reason="tool_use",
+        ),
+        _response(content=[_text("done")], stop_reason="end_turn"),
+    ]
+
+    agent = ChartSummary()
+    result = agent.run(
+        AgentState(),
+        gateway,
+        {"patient_id": patient.id, "note_id": "note-uuid"},
+    )
+
+    # The accumulator should have the originated Plan command.
+    assert len(result.effects) == 1
+    # Three turns happened: find_conditions, originate_plan, end_turn.
+    assert mock_client.messages.create.call_count == 3
+```
+
+Walk-through:
+- The `side_effect` is a list — each call to `messages.create()`
+  pops the next response.
+- `tool_use` responses cause the agent's loop to dispatch the named
+  tool through `self.tools.execute(...)` and append the result on the
+  next turn.
+- `end_turn` exits the loop.
+- The accumulator (`result.effects`) holds whatever effect tools
+  staged during the run.
+
+## Simulating the platform's manifest-scoping
+
+Recall that the platform replaces `agent.tools` with a scoped view
+before `run()` fires. In tests you do this yourself if you want to
+exercise the filter.
+
+```python
+def _make_agent(agent_cls, tools_allowed=None):
+    """Instantiate an agent the way the platform would."""
+    agent = agent_cls()
+    if tools_allowed is not None:
+        agent.tools_allowed = frozenset(tools_allowed)
+        agent.tools = agent_cls.tools.scope(agent.tools_allowed)
+    return agent
+```
+
+Use this anywhere `tools.allowed` matters to what you're testing:
+
+```python
+def test_run_cannot_use_disallowed_tool(gateway):
+    """When the manifest withholds a tool, the agent can't call it."""
+    agent = _make_agent(ChartSummary, tools_allowed={"find_conditions"})
+
+    # find_conditions is in the scope, originate_plan is not.
+    assert {"find_conditions"} == {
+        d["name"] for d in agent.tools.definitions()
+    }
+    with pytest.raises(ValueError, match="Unknown tool"):
+        agent.tools.execute("originate_plan", {"narrative": "..."}, ctx={})
+```
+
+The scoped registry doesn't contain disallowed entries at all — a
+test for "the agent shouldn't be able to do X" can assert on
+`Unknown tool` rather than checking permission state.
+
+## State transitions
+
+For agents that aren't stateless, test `load_state` and `save_state`
+independently of `run()`. They're plain methods.
+
+```python
+def test_load_state_returns_existing_messages(patient_factory, conversation_factory):
+    """load_state pulls the conversation snapshot for this patient."""
+    patient = patient_factory()
+    conversation_factory(
+        patient=patient,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    state = ChartChatAgent().load_state(
+        f"my_plugin:chart_chat:patient:{patient.id}"
+    )
+
+    assert state.data["messages"] == [{"role": "user", "content": "hi"}]
+    assert state.data["patient_id"] == patient.id
+
+
+def test_save_state_writes_back_appended_messages(patient_factory):
+    """save_state persists the (mutated) state.data['messages'] list."""
+    patient = patient_factory()
+    state = AgentState(
+        data={
+            "patient_id": patient.id,
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        }
+    )
+
+    ChartChatAgent().save_state(
+        f"my_plugin:chart_chat:patient:{patient.id}",
+        state,
+    )
+
+    from my_plugin.models import Conversation
+    row = Conversation.objects.get(patient__id=patient.id)
+    assert len(row.messages) == 2
+```
+
+End-to-end coverage of the snapshot pattern: write a `load_state →
+run → save_state` test that mocks the Anthropic loop and asserts on
+the final row in your CustomModel table.
+
+## Testing lifecycle hooks
+
+If you've overridden `on_run_start` / `on_run_end` / `on_run_error`
+(for example, via a `RunLoggingMixin`), invoke them directly. The
+platform's `_invoke_agent_hook` helper that swallows hook
+exceptions doesn't change their signatures.
+
+```python
+def test_on_run_end_writes_audit_row(patient_factory):
+    agent = MyAgent()
+    agent.on_run_start("scope-key-1")
+
+    agent.on_run_end(AgentRunResult(state=AgentState(), effects=[]))
+
+    from my_plugin.models import AgentRunLog
+    row = AgentRunLog.objects.get(scope_key="scope-key-1")
+    assert row.status == "success"
+    assert row.duration_ms is not None
+```
+
+If you want to verify the platform's "swallow hook exceptions"
+behavior in your own code, raise from the hook and assert that
+something downstream still works. (You usually don't need to — the
+SDK's plugin-runner tests cover that path.)
+
+## Integration tests through the plugin-runner
+
+For end-to-end coverage — a real `RunAgentEffect` flowing from a
+trigger through Celery and the gRPC RunAgent RPC — Canvas's
+plugin test fixtures install your plugin into a test plugin-runner
+and let you assert on emitted effects via `handle_effect`.
+This is heavier than the unit patterns above and typically saved
+for a handful of golden-path scenarios per agent. See
+[Testing Utilities](/sdk/testing-utils/) for the full setup.
+
+A useful split:
+
+- **Unit** — individual tool executors, `load_state`/`save_state`,
+  lifecycle hooks. Fast, no Anthropic mock needed.
+- **Run-loop** — `run()` with a mocked Anthropic client. Exercises
+  the tool-use dispatch and the effects accumulator.
+- **Integration** — one or two end-to-end runs per agent, asserting
+  that effects land where they should. Slow; uses the test
+  plugin-runner.
+
+## Don't pin to real provider responses
+
+It's tempting to record real Anthropic responses and replay them.
+That's a brittle test foundation — the model's tool-call sequence
+varies run-to-run, the response shape evolves with API versions, and
+the cost is borne by your CI. Hand-built canned responses (the
+`_response` / `_tool_use` / `_text` helpers above) give you tests
+that exercise *your* loop logic, not the model's tendencies.
+
+Real-provider tests belong in an evals harness — a small set of
+representative `trigger_payload`s you run manually before releases.
+See [Auditing](/sdk/agents-auditing/) for the evals/replay story.

--- a/collections/_sdk/agents/tools.md
+++ b/collections/_sdk/agents/tools.md
@@ -1,0 +1,1246 @@
+---
+title: "Tools"
+slug: "agents-tools"
+excerpt: "How agents discover and call functions on the EHR — and how you authorize them."
+---
+
+A tool is a named function paired with a JSON-Schema describing its
+inputs. The agent advertises tools to the LLM; the LLM picks one,
+chooses arguments, and asks the agent to invoke it; the agent
+dispatches to the matching executor and feeds the result back into
+the model on the next turn.
+
+The SDK gives you a `ToolRegistry` to hold the catalog, a built-in
+`standard_tools` set of clinical reads, and a manifest-driven
+permission filter so the EHR administrator (not the agent itself)
+controls which tools any given agent can use.
+
+## The two kinds of tools
+
+**Read tools** answer questions about the chart. They don't change
+state; the agent uses them to inform its decisions. The SDK ships a
+broad clinical-reads catalog in `standard_tools` — medications,
+conditions, labs, allergies, immunizations, vitals, tasks,
+appointments, encounters, goals, imaging reports, referrals, care
+team, prescriptions, banner alerts, and more — see the full list
+in the [catalog section](#the-sdk-standard_tools-catalog) below.
+
+**Effect tools** stage Canvas Effects (draft commands, tasks, banner
+alerts, etc.) into a shared accumulator that the agent returns from
+`run()`. The platform dispatches each emitted effect through
+`handle_effect` exactly once *after* the run completes — the model
+decides *what* to emit; the platform decides *when*. Effect tools
+typically never commit anything outright; they originate drafts the
+clinician then reviews.
+
+## Defining a registry
+
+Plugin authors register tools at module-import time. Mix the SDK's
+standard tools with your own.
+
+The SDK ships three opinionated helpers — `filter_search_tool`,
+`originate_command_tool`, and `add_effect_tool` — that take a
+declarative spec and synthesize the JSON Schema, executor wiring,
+and registration for you. Use them when your tool fits one of the
+three common shapes; fall back to the raw `tool()` decorator for
+anything bespoke.
+
+```python
+from datetime import date, timedelta
+from uuid import uuid4
+
+from canvas_sdk.agents import EffectField, FilterSpec, ToolRegistry, standard_tools
+from canvas_sdk.commands import PrescribeCommand
+from canvas_sdk.effects.task.task import AddTask
+from canvas_sdk.v1.data import Condition
+
+tools = ToolRegistry()
+tools.extend(standard_tools)  # adopt the SDK catalog
+
+
+# READ — filter-spec tool. The decorated function is the per-row
+# serializer; the helper handles JSON Schema synthesis, patient-scope
+# enforcement via queryset_factory, filter application, ordering, and
+# limit clamping.
+@tools.filter_search_tool(
+    name="find_chronic_conditions",
+    description=(
+        "Search the patient's chronic conditions — active conditions "
+        "with onset more than six months ago."
+    ),
+    queryset_factory=lambda args, pid: Condition.objects.active().filter(
+        patient__id=pid,
+        onset_date__lte=date.today() - timedelta(days=180),
+    ),
+    filters={
+        "name_contains": FilterSpec(
+            type="string",
+            description="Substring match on the coding display.",
+            apply=lambda qs, v: qs.filter(codings__display__icontains=v),
+        ),
+    },
+    prefetch_related=("codings",),
+    model=Condition,
+    returns_description="Each row: id, code, display, onset_date.",
+    categories=("clinical_reads",),
+)
+def _serialize_chronic_condition(condition):
+    coding = condition.codings.first()
+    return {
+        "id": str(condition.id),
+        "code": coding.code if coding else None,
+        "display": coding.display if coding else "(unknown)",
+        "onset_date": (
+            condition.onset_date.isoformat() if condition.onset_date else None
+        ),
+    }
+
+
+# WRITE — note-bound originate-command tool. The helper resolves the
+# target note from ctx, instantiates the Command, calls .originate(),
+# and appends the resulting Effect. NEVER commits — the clinician
+# reviews the draft in the chart UI.
+tools.originate_command_tool(
+    name="originate_prescribe_medication",
+    description=(
+        "Stage a draft Prescribe command on the patient's current open "
+        "note for the clinician to review, edit, and commit."
+    ),
+    command_class=PrescribeCommand,
+    fields={
+        "sig": EffectField(
+            type="string",
+            description="Patient instructions (e.g., 'Take 1 tablet daily').",
+            required=True,
+        ),
+        "fdb_code": EffectField(
+            type="string",
+            description="FDB code identifying the medication.",
+        ),
+    },
+    categories=("clinical_writes",),
+)
+
+
+# WRITE — non-note-bound Effect tool. The helper auto-injects
+# patient_id from ctx and lets you generate UUIDs or transform field
+# values in pre_build. response_builder shapes the dict returned to
+# the model on success.
+tools.add_effect_tool(
+    name="create_followup_task",
+    description=(
+        "Create a follow-up task tagged with the 'follow-up' label so "
+        "the triage workflow can route it."
+    ),
+    effect_class=AddTask,
+    fields={
+        "title": EffectField(type="string", description="Task title.", required=True),
+    },
+    pre_build=lambda args, ctx: {
+        "id": str(uuid4()),
+        "title": args["title"].strip()[:200],
+        "labels": ["follow-up"],
+    },
+    response_builder=lambda effect: {"ok": True, "task_id": str(effect.id)},
+    categories=("task_writes",),
+)
+```
+
+### When to use which helper
+
+- **`filter_search_tool`** — patient-scoped reads with optional
+  filters. The decorated function serializes one row. The model gets
+  one tool that combines filter arguments, rather than many narrow
+  tools. Used by almost every `find_*` in the SDK catalog.
+- **`originate_command_tool`** — staging a draft chart Command on the
+  patient's current note. Resolves the note from `ctx["note_id"]` by
+  default (override `note_resolver` if your agent finds the note
+  differently). Patient scope flows through the Command.
+- **`add_effect_tool`** — patient-scoped Effects that aren't pinned
+  to a specific note (tasks, banner alerts, protocol cards). Auto-
+  injects `patient_id` from ctx onto the Effect; `inject_ctx={}` to
+  opt out (e.g., for `update_task` which is identified by `task_id`,
+  not derived from the current patient).
+
+### Escape hatch: `@tools.tool`
+
+For tools that don't fit any of the three helper shapes — scalar
+reads that return a fixed-shape object, custom workflows that span
+multiple Effects, integrations with non-Canvas APIs — drop down to
+the raw decorator and hand-build the executor:
+
+```python
+@tools.tool(
+    name="get_visit_pattern",
+    description="Return a summary of the patient's visit frequency.",
+    input_schema={"type": "object", "properties": {}},
+    returns_description="Object with `visits_last_year` and `avg_days_between_visits`.",
+    categories=("clinical_reads",),
+)
+def _get_visit_pattern(arguments, *, ctx):
+    patient_id = ctx["patient_id"]
+    # ...compute summary from Appointment queryset...
+    return {"visits_last_year": 4, "avg_days_between_visits": 92}
+```
+
+The SDK's `get_patient_demographics` is registered this way for
+exactly this reason — it returns one dict, not a list, so it doesn't
+fit `filter_search_tool`.
+
+## Executor signature
+
+The helpers generate executors with this signature behind the scenes;
+you only write one directly when using the raw `@tools.tool`
+decorator. Either way, every executor takes the same two arguments:
+
+```python
+def my_tool(arguments: dict, *, ctx: dict) -> Any: ...
+```
+
+- `arguments` — the model's `tool_use.input` dict. The model chose
+  these values from the input schema. Validate as needed before use.
+- `ctx` — the platform's per-run context. The model never sees this.
+  Common keys:
+  - `patient_id` — string UUID of the patient this run is scoped to.
+  - `note_id` — for triggered agents that target a specific note.
+  - `effects` — the list to append staged Effects to (used by effect tools).
+
+Use `ctx` for anything the model shouldn't choose — patient scoping,
+note targeting, the effects accumulator. Never trust `arguments` for
+scope (a malicious or hallucinating model could try to switch
+patients via an argument). The SDK's `standard_tools` enforce scope
+this way: `find_medications` reads `ctx["patient_id"]` and filters
+the query on it regardless of what the model passes.
+
+## Attaching tools to an agent
+
+Declare the registry as a class attribute on your `AgentPlugin`
+subclass:
+
+```python
+from my_plugin.agents.chart_summary_tools import tools as _registered_tools
+
+class ChartSummary(AgentPlugin):
+    tools = _registered_tools
+
+    def run(self, state, gateway, trigger_payload):
+        # self.tools is the manifest-scoped view — already filtered.
+        # Use it, not the imported _registered_tools.
+        client.messages.create(tools=self.tools.definitions(), ...)
+        result = self.tools.execute(name, args, ctx=tool_ctx)
+```
+
+Inside `run()`, always use `self.tools` — that's the platform-scoped
+view (see [Permissions](#manifest-driven-permissions)). The
+underscore on `_registered_tools` is a convention to signal "don't
+reach for me directly."
+
+## Definitions for the model
+
+`self.tools.definitions()` returns a list of dicts shaped for the
+Anthropic tool-use API:
+
+```python
+[
+    {"name": "find_medications", "description": "...", "input_schema": {...}},
+    {"name": "originate_plan", "description": "...", "input_schema": {...}},
+]
+```
+
+Hand this list to `client.messages.create(tools=...)`.
+
+## Dispatching a tool call
+
+When the model returns a `ToolUseBlock`, dispatch it through the
+registry:
+
+```python
+try:
+    result = self.tools.execute(block.name, dict(block.input), ctx=tool_ctx)
+    tool_results.append({
+        "type": "tool_result",
+        "tool_use_id": block.id,
+        "content": json.dumps(result, default=str),
+    })
+except Exception as exc:
+    tool_results.append({
+        "type": "tool_result",
+        "tool_use_id": block.id,
+        "content": f"Tool failed: {exc!s}",
+        "is_error": True,
+    })
+```
+
+Errors should go back to the model as `is_error=True` `tool_result`
+blocks rather than crashing the run — the model will self-correct on
+the next turn (typically by trying different arguments or a
+different tool).
+
+## Manifest-driven permissions
+
+The agent's `tools.allowed` declaration in `CANVAS_MANIFEST.json` is
+the contract:
+
+```jsonc
+{
+  "components": {
+    "agents": [
+      {
+        "class": "my_plugin.agents.chart_chat:ChartChatAgent",
+        "description": "Chat agent over the patient chart",
+        "tools": {
+          "allowed": [
+            "find_medications",
+            "find_conditions",
+            "create_task",
+            "originate_prescribe_medication"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+At run time the platform:
+
+1. Reads `tools.allowed` from the manifest entry for this agent.
+2. Sets `self.tools_allowed = frozenset(tools.allowed)`.
+3. Replaces `self.tools` with a *scoped* registry containing only
+   those tools — disallowed entries aren't in the registry at all.
+
+After step 3, `self.tools.definitions()` returns only the allowlisted
+subset (the model never sees the others) and
+`self.tools.execute("disallowed_name", ...)` raises `ValueError`
+because the executor isn't reachable. There's no per-call `allowed=`
+parameter to remember — the registry itself is pre-filtered.
+
+**Why this matters**: the manifest is the single source of truth.
+The EHR administrator reviewing your plugin can read the manifest
+and know exactly which tools each agent can use. The agent code
+can't widen that surface — even accidentally — because `self.tools`
+is the only handle the platform hands it.
+
+A determined plugin author could `from my_plugin.agents.chart_chat_tools
+import tools` directly and reach the unfiltered registry. That gap
+will close in a future release via sandbox-level isolation; for now,
+treat the unfiltered registry as platform-internal. The underscore-
+prefixed import convention is meant to remind future-you.
+
+## Tool surface design tips
+
+- **Be specific in `description`.** The model picks tools based on
+  the description alone. Mention what the tool returns and when to
+  use it. Compare:
+  - Bad: "Returns medications."
+  - Good: "Returns the patient's medications with optional filters
+    (`name_contains`, `active_only`, `started_on_or_after`). Use
+    this when the conversation needs current or historical
+    prescription info."
+- **Prefer filter-spec tools over many narrow tools.** One tool with
+  filter parameters (`find_medications(name_contains?, active_only?,
+  ...)`) is easier for the model than five overlapping tools
+  (`find_active_medications`, `find_recent_medications`, ...). The
+  SDK's `standard_tools` use this pattern.
+- **Enforce scope in `ctx`, never in `arguments`.** `patient_id`
+  comes from the platform's `ctx`; the model can't switch patients
+  via tool arguments.
+- **Return JSON-serializable values.** The agent's loop typically
+  does `json.dumps(result, default=str)` to feed it back to the
+  model.
+- **For effect tools, return a small confirmation dict, not the
+  whole effect.** The model only needs to know the call succeeded;
+  details of the staged effect are platform-side concerns.
+- **Originate, don't commit.** Effect tools that stage chart
+  commands should call `.originate()` (draft), not `.commit()`. The
+  clinician reviews the draft in the chart UI.
+
+## The SDK `standard_tools` catalog
+
+The SDK ships an opinionated catalog of clinical reads and writes
+behind `canvas_sdk.agents.standard_tools`. Patient scope is enforced
+by each tool — you can't widen it via filter arguments. The catalog
+is grouped into manifest-friendly `@category` tags so plugin authors
+can grant access by tool family rather than enumerating every name.
+
+The sections below are auto-generated from the registry — they
+reflect the SDK version pinned in your plugin's environment. Hand
+edits inside the `<!-- AUTOGEN -->` markers will be overwritten on
+the next regeneration.
+
+### By category
+
+Grant a category in your manifest with the `@` prefix (e.g.,
+`"allowed": ["@clinical_reads", "@task_writes"]`). Add a `denied`
+list to opt out of specific tools within a granted category:
+
+```jsonc
+{
+  "tools": {
+    "allowed": ["@clinical_reads", "@clinical_writes"],
+    "denied": ["originate_diagnose_condition"]
+  }
+}
+```
+
+<!-- AUTOGEN:categories START -->
+- **`@clinical_alerts`** (3 tools): `add_banner_alert`, `remove_banner_alert`, `add_or_update_protocol_card`
+- **`@clinical_reads`** (24 tools): `find_medications`, `find_conditions`, `find_lab_results`, `find_assessments`, `find_allergies`, `find_immunizations`, `find_vitals`, `find_appointments`, `find_encounters`, `find_notes`, `get_open_note`, `get_note_content`, `find_goals`, `find_imaging_reports`, `find_referrals`, `find_care_team_members`, `find_medication_statements`, `find_external_events`, `find_prescriptions`, `find_questionnaire_responses`, `find_stop_medication_events`, `find_banner_alerts`, `find_protocol_cards`, `get_patient_demographics`
+- **`@clinical_writes`** (9 tools): `originate_review_note`, `originate_plan`, `originate_prescribe_medication`, `originate_lab_order`, `originate_diagnose_condition`, `originate_goal`, `originate_assessment`, `originate_follow_up`, `originate_stop_medication`
+- **`@config_reads`** (4 tools): `find_note_types`, `find_practice_locations`, `find_lab_partners`, `find_lab_partner_tests`
+- **`@message_reads`** (1 tool): `find_messages`
+- **`@message_writes`** (1 tool): `originate_message`
+- **`@task_reads`** (1 tool): `find_tasks`
+- **`@task_writes`** (3 tools): `create_task`, `update_task`, `add_task_comment`
+<!-- AUTOGEN:categories END -->
+
+### Reads
+
+The clinical reads. Patient scope is enforced internally; row `id`
+fields chain into write tools that need them (e.g., the `id` from
+`find_conditions` feeds `originate_assessment` in a plugin-side
+originate-command tool).
+
+<!-- AUTOGEN:reads START -->
+#### `find_medications`
+
+**Category:** `@clinical_reads`
+
+Search the patient's medications with optional filters. Returns each matching medication as an object with `name` (display from the first coding, typically RxNorm), `status` ("active" or "inactive"), `start_date` (ISO 8601 or null), and `end_date` (ISO 8601 or null). Patient scope is enforced — the tool only returns records for the current agent's patient. If no filters are supplied, returns the most recent records by start_date.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match against the medication's first-coding display. E.g. 'metformin' matches 'Metformin 500 mg tablet'. |
+| `active_only` | boolean | no | When true, restrict to active (status='active', committed) medications. When false or omitted, include inactive too. |
+| `started_on_or_after` | string (date) | no | ISO 8601 date (YYYY-MM-DD). When supplied, only return medications with start_date >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `name`, `status` (active|inactive), `start_date` (ISO 8601 or null), `end_date` (ISO 8601 or null).
+
+**Backing data model:** `Medication`.
+
+#### `find_conditions`
+
+**Category:** `@clinical_reads`
+
+Search the patient's conditions with optional filters. Returns each matching condition with `code` (the first coding's identifier — typically ICD-10), `display`, `clinical_status` (active, resolved, remission, relapse, investigative), `onset_date` (ISO 8601 or null), and `resolution_date` (ISO 8601 or null). Defaults to active conditions only, ordered most-recently-onset first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the coding display (e.g. 'diabetes'). |
+| `code_contains` | string | no | Case-insensitive substring match on the coding code (e.g. 'E11' for type-2 diabetes ICD-10 family). |
+| `active_only` | boolean | no | When true (default), restrict to currently-active conditions. When false, include resolved/remission/etc. |
+| `onset_on_or_after` | string (date) | no | ISO 8601 date. Only return conditions with onset_date >= this. |
+| `limit` | integer | no | Max results. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `code`, `display`, `clinical_status` (active|resolved|remission|relapse|investigative), `onset_date`, `resolution_date`.
+
+**Backing data model:** `Condition`.
+
+#### `find_lab_results`
+
+**Category:** `@clinical_reads`
+
+Search the patient's committed lab results. Returns each matching value with `test` (lab name), `value`, `units`, `abnormal_flag` (e.g. 'H', 'L', or null when normal), and `date` (the report's original_date, ISO 8601). Defaults to the 10 most-recent results.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the lab's coding name (e.g. 'a1c', 'hemoglobin'). |
+| `observed_on_or_after` | string (date) | no | ISO 8601 date. Only return results with date >= this. |
+| `abnormal_only` | boolean | no | When true, restrict to values with a non-empty abnormal_flag. Useful for spotting out-of-range results quickly. |
+| `limit` | integer | no | Max results. Defaults to 10. |
+
+**Returns:** Array of objects with `id`, `test`, `value`, `units`, `abnormal_flag` (e.g. 'H', 'L', or null), `date`.
+
+**Backing data model:** `LabValue`.
+
+#### `find_assessments`
+
+**Category:** `@clinical_reads`
+
+Return the patient's recent clinical assessments (the structured Assess command's status + narrative on a note). Each result has `status` ('improved', 'stable', 'deteriorated'), `narrative`, `background`, `condition_display` (the associated condition's name, if any), and `date` (the source note's datetime_of_service, ISO 8601). Ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `limit` | integer | no | Max results. Defaults to 10. |
+
+**Returns:** Array of objects with `id`, `status`, `narrative`, `background`, `condition_display`, `date`.
+
+**Backing data model:** `Assessment`.
+
+#### `find_allergies`
+
+**Category:** `@clinical_reads`
+
+Search the patient's documented allergies and intolerances. Returns each entry with `display` (allergen name from the first coding), `code` (typically RxNorm or SNOMED), `severity` (e.g., 'mild', 'moderate', 'severe'), `narrative` (free-text reaction description), `status`, and `onset_date` (ISO 8601 or null). Patient scope is enforced. Defaults to non-deleted committed entries, ordered most-recently-onset first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the allergen's display (e.g., 'penicillin', 'peanut', 'sulfa'). |
+| `severity` | string | no | Filter to a specific severity. Common values: 'mild', 'moderate', 'severe'. Match is case-insensitive exact. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `display`, `code`, `severity`, `narrative`, `status`, `onset_date`.
+
+**Backing data model:** `AllergyIntolerance`.
+
+#### `find_immunizations`
+
+**Category:** `@clinical_reads`
+
+Search the patient's immunization history. Returns each entry with `display` (vaccine name from the first coding, typically CVX), `code`, `date_administered` (ISO 8601 or null), `status` (e.g., 'administered', 'refused'), `manufacturer`, and `lot_number`. Patient scope is enforced. Ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the vaccine's display (e.g., 'influenza', 'covid', 'tdap', 'mmr'). |
+| `given_on_or_after` | string (date) | no | ISO 8601 date. Only return immunizations with date_ordered >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `display`, `code`, `given_on`, `status`.
+
+**Backing data model:** `Immunization`.
+
+#### `find_vitals`
+
+**Category:** `@clinical_reads`
+
+Search the patient's recorded vital signs — blood pressure, heart rate, temperature, weight, height, BMI, respiratory rate, oxygen saturation, and similar measurements (any Observation in the FHIR `vital-signs` category). Returns each measurement with `name`, `value`, `units`, `code` (typically LOINC from the first coding), and `date` (ISO 8601 effective_datetime). Patient scope is enforced. Defaults to the 10 most recent.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the observation's name (e.g., 'blood pressure', 'weight', 'temperature', 'pulse'). |
+| `observed_on_or_after` | string (date) | no | ISO 8601 date. Only return measurements with effective_datetime >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 10. |
+
+**Returns:** Array of objects with `id`, `name`, `value`, `units`, `observed_at`.
+
+**Backing data model:** `Observation`.
+
+#### `find_tasks`
+
+**Category:** `@task_reads`
+
+Search tasks linked to the current patient (clinician follow-ups, outreach reminders, etc.). Returns each task with `id`, `title`, `status` ('OPEN', 'COMPLETED', 'CLOSED'), `due` (ISO 8601 or null), and `task_type`. Defaults to OPEN tasks ordered by due date.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `status` | string (enum) | no | Filter to a specific status. If omitted, defaults to OPEN tasks only. One of: `COMPLETED`, `CLOSED`, `OPEN`. |
+| `title_contains` | string | no | Case-insensitive substring match on the task title. |
+| `due_on_or_after` | string (date) | no | ISO 8601 date. Only return tasks with due >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `title`, `status`, `due` (ISO 8601), `assignee_name`, `team_name`, `labels`, `created`.
+
+**Backing data model:** `Task`.
+
+#### `find_messages`
+
+**Category:** `@message_reads`
+
+Search the patient's messages (clinician ↔ patient correspondence via the patient portal). Returns each message with `id`, `content`, `sender_role` ('patient' or 'staff'), `sender_name`, `recipient_role`, `recipient_name`, `sent_at` (ISO 8601), and `read_at` (ISO 8601 or null). Defaults to the 20 most recent. Use `from_patient_only=true` to see only incoming messages from the patient (e.g., to draft a reply); `unread_only=true` to scope to messages the recipient hasn't read yet; `since=YYYY-MM-DD` to look at a recent window.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `from_patient_only` | boolean | no | When true, restrict to messages where the sender is a patient (i.e., incoming messages from this patient to their care team). Useful for finding the latest message to reply to. |
+| `unread_only` | boolean | no | When true, restrict to messages with no `read` timestamp yet — i.e., the recipient hasn't opened them. |
+| `since` | string (date) | no | ISO 8601 date. Only return messages with created >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 20. |
+
+**Returns:** Array of objects with `id`, `content`, `sender_role` ('patient'|'staff'), `sender_name`, `recipient_role`, `recipient_name`, `sent_at`, `read_at`.
+
+**Backing data model:** `Message`.
+
+#### `find_appointments`
+
+**Category:** `@clinical_reads`
+
+Search the patient's appointments. Returns each appointment with `id`, `status`, `start_time` (ISO 8601), `duration_minutes`, `provider_name`, and `description`. Defaults to upcoming appointments ordered by start_time ascending; pass `upcoming_only=false` to include past appointments.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `status` | string (enum) | no | Filter to a specific appointment progress status. Values track the workflow from booking to completion: 'unconfirmed' (booked, not yet confirmed), 'attempted', 'confirmed', 'arrived', 'roomed', 'exited' (visit completed), 'noshowed', 'cancelled'. One of: `unconfirmed`, `attempted`, `confirmed`, `arrived`, `roomed`, `exited`, `noshowed`, `cancelled`. |
+| `starts_on_or_after` | string (date) | no | ISO 8601 date. Only return appointments with start_time >= this. |
+| `starts_on_or_before` | string (date) | no | ISO 8601 date. Only return appointments with start_time <= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `start_time` (ISO 8601), `status`, `appointment_type`, `provider_name`, `note_type`.
+
+**Backing data model:** `Appointment`.
+
+#### `find_encounters`
+
+**Category:** `@clinical_reads`
+
+Search the patient's encounters. Returns each encounter with `id`, `state`, `medium` (e.g., 'in-person', 'phone', 'telehealth'), `start_time` (ISO 8601 or null), and `end_time` (ISO 8601 or null). Defaults to the 25 most-recent encounters ordered by start_time descending.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `state` | string (enum) | no | Filter to a specific encounter state. Three-letter codes: 'STA' (Started), 'PLA' (Planned), 'CON' (Concluded), 'CAN' (Cancelled). One of: `STA`, `PLA`, `CON`, `CAN`. |
+| `started_on_or_after` | string (date) | no | ISO 8601 date. Only return encounters with start_time >= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `state` (new|locked|unlocked|...), `note_type`, `started_at`, `provider_name`.
+
+**Backing data model:** `Encounter`.
+
+#### `find_notes`
+
+**Category:** `@clinical_reads`
+
+Search the patient's notes (encounter documents). Each row has `id`, `title`, `note_type`, `state` (3-letter code from NoteStates — e.g. 'NEW' (Created), 'LKD' (Locked), 'ULK' (Unlocked), 'SGN' (Signed)), `datetime_of_service`, and `provider_name`. Filter by `state` to find open vs locked notes, by `note_type` to scope to a category, or by `since` to look at recent history only. Defaults to most-recent-first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `state` | string (enum) | no | Restrict to notes in a specific lifecycle state. Three-letter NoteStates code — pick from the enum. Filters on the canonical current state, not the note's initial state. Common values: 'NEW' (created/open), 'LKD' (locked), 'ULK' (unlocked), 'SGN' (signed), 'DLT' (deleted). One of: `NEW`, `PSH`, `LKD`, `ULK`, `DLT`, `RLK`, `RST`, `RCL`, `UND`, `DSC`, `SGN`, `SCH`, `BKD`, `CVD`, `CLD`, `NSW`, `RVT`, `CNF`. |
+| `note_type` | string (enum) | no | Restrict to notes whose category matches. Broad bucket from NoteTypeCategories (the canonical category enum). Common values: 'encounter' (catch-all for in-person / telehealth / phone / video / home / lab visits), 'inpatient', 'review' (chart review), 'message', 'letter', 'appointment'. For a more specific match like 'Telehealth' vs 'Office visit' (both encounter), use `note_type_name_contains`. One of: `message`, `letter`, `inpatient`, `review`, `encounter`, `appointment`, `task`, `data`, `ccda`, `schedule_event`. |
+| `note_type_name_contains` | string | no | Case-insensitive substring match on the note type's display name (e.g., 'Telehealth', 'Office visit', 'Chart review', 'Home visit'). More granular than `note_type` — use to disambiguate within a category. |
+| `since` | string (date) | no | ISO 8601 date. Only return notes with datetime_of_service >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id` (UUID), `dbid` (integer — Canvas-internal navigation handle), `title`, `note_type` (NoteTypeCategories enum value — e.g., 'encounter', 'inpatient', 'review'), `note_type_name` (the type's display name — e.g., 'Telehealth', 'Office visit', 'Chart review'), `state` (NoteStates code or null), `datetime_of_service` (ISO 8601), `provider_name`.
+
+**Backing data model:** `Note`.
+
+#### `get_open_note`
+
+**Category:** `@clinical_reads`
+
+Return metadata for the patient's current open note (the most-recent note in a mutable state — NEW, UNLOCKED, or CONVERTED). Use this when the user references 'this note' or 'the open note' and the agent needs the note_id to drill into it or stage a command on it. Returns the same row shape as one find_notes entry, or null if no open note exists.
+
+**Arguments:** none.
+
+**Returns:** Object matching find_notes' row shape (`id`, `dbid`, `title`, `note_type`, `note_type_name`, `state`, `datetime_of_service`, `provider_name`), or null if the patient has no notes in an open state.
+
+#### `get_note_content`
+
+**Category:** `@clinical_reads`
+
+Read the contents of a specific note in document order — the free-text narrative the clinician typed interleaved with the structured clinical commands they committed (Plan, Assess, Diagnose, Prescribe, LabOrder, etc.). Use this when the user asks about a specific note ('what's in this note?', 'did today's visit address X?', 'summarize the assessment') so the agent can answer without the clinician having to re-read the note themselves. Skips entered-in-error commands and empty text blocks. Patient scope is enforced — a note belonging to a different patient returns null.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `note_id` | string | yes | UUID of the note to read. From a prior find_notes or get_open_note call (the row's `id` field). |
+
+**Returns:** Object with the note's metadata (`id`, `dbid`, `title`, `note_type`, `note_type_name`, `state`, `datetime_of_service`, `provider_name`) plus a `content` array of items in document order. Each item is either `{type: 'text', value: <free-text>}` (the clinician's narrative between commands) or `{type: 'command', uuid, schema_key, state, data}` (a structured chart command — schema_key like 'plan'/'assess'/'labOrder', data containing the command-specific fields). Returns null if no note with that id exists for the current patient.
+
+#### `find_goals`
+
+**Category:** `@clinical_reads`
+
+Search the patient's care-plan goals. Returns each goal with `goal_statement`, `lifecycle_status` (e.g., 'active', 'completed', 'cancelled'), `achievement_status` (e.g., 'in-progress', 'achieved'), `priority` ('high-priority', 'medium-priority', 'low-priority'), `start_date` (ISO 8601 or null), `due_date` (ISO 8601 or null), and `progress` (free-text note). Defaults to active goals ordered by most-recent start_date.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `statement_contains` | string | no | Case-insensitive substring match on the goal_statement text. |
+| `lifecycle_status` | string (enum) | no | Filter to a specific GoalLifecycleStatus value (e.g., 'active', 'completed', 'cancelled'). One of: `proposed`, `planned`, `accepted`, `active`, `on-hold`, `completed`, `cancelled`, `rejected`. |
+| `achievement_status` | string (enum) | no | Filter to a specific GoalAchievementStatus value (e.g., 'in-progress', 'achieved', 'not-achieved'). One of: `in-progress`, `improving`, `worsening`, `no-change`, `achieved`, `sustaining`, `not-achieved`, `no-progress`, `not-attainable`. |
+| `priority` | string (enum) | no | Filter to a specific GoalPriority value ('high-priority', 'medium-priority', 'low-priority'). One of: `high-priority`, `medium-priority`, `low-priority`. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `goal_statement`, `lifecycle_status`, `achievement_status`, `priority`, `start_date`, `due_date`.
+
+**Backing data model:** `Goal`.
+
+#### `find_imaging_reports`
+
+**Category:** `@clinical_reads`
+
+Search the patient's imaging reports. Returns each report with `id`, `name` (test or modality, e.g., 'Chest X-ray'), `assigned_date` (ISO 8601 or null), `source` (e.g., 'internal', 'external'), and `requires_signature` (bool). Patient scope is enforced and junked reports are excluded. Defaults to the 25 most-recent reports.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the report name (e.g., 'chest', 'mammo', 'mri'). |
+| `assigned_on_or_after` | string (date) | no | ISO 8601 date. Only return reports with assigned_date >= this value. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `name`, `result_status`, `assigned_at`, `narrative`.
+
+**Backing data model:** `ImagingReport`.
+
+#### `find_referrals`
+
+**Category:** `@clinical_reads`
+
+Search the patient's outgoing referrals. Returns each referral with `id`, `clinical_question`, `priority`, `notes` (free-text), `date_referred` (ISO 8601), `service_provider_name`, and `forwarded` (bool). Ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `question_contains` | string | no | Case-insensitive substring match on the clinical_question field. |
+| `priority` | string | no | Filter to a specific priority (free-text on Referral; values depend on the customer's configuration). Case-insensitive. |
+| `referred_on_or_after` | string (date) | no | ISO 8601 date. Only return referrals with date_referred >= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `service_provider_name`, `clinical_question`, `priority`, `status`, `originated_at`.
+
+**Backing data model:** `Referral`.
+
+#### `find_care_team_members`
+
+**Category:** `@clinical_reads`
+
+Return the staff members on the patient's care team. Each result has `staff_name`, `role_display` (e.g., 'Primary Care Provider', 'Care Manager'), `role_code`, `status` (e.g., 'active', 'inactive'), and `is_lead` (true for the patient's primary contact). Ordered with the lead member first, then by role.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `role_contains` | string | no | Case-insensitive substring match on role_display (e.g., 'primary', 'manager'). |
+| `status` | string (enum) | no | Filter to a specific CareTeamMembershipStatus value (e.g., 'active', 'inactive', 'suspended', 'proposed'). One of: `proposed`, `active`, `suspended`, `inactive`, `entered-in-error`. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `staff_name`, `role`, `lead`, `status`.
+
+**Backing data model:** `CareTeamMembership`.
+
+#### `find_note_types`
+
+**Category:** `@config_reads`
+
+List the customer's configured NoteType rows. Returns each type with `id` (the UUID to pass as `note_type_id` to note-creation tools), `name` (display name shown in the UI), `category` (NoteTypeCategories enum value: 'encounter', 'review', 'data', 'task', 'inpatient', 'letter', 'message', 'appointment', 'schedule_event', 'ccda'), `is_active`, and `is_visible`. Customer-level config — NOT patient-scoped; the patient_id on ctx is ignored. Use to resolve a friendly handle ('chart review note', 'office visit') into the UUID note-write tools need.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `category` | string (enum) | no | Restrict to a single NoteTypeCategories value — e.g. 'review' for chart-review notes, 'encounter' for visit notes, 'letter' for letters. One of: `message`, `letter`, `inpatient`, `review`, `encounter`, `appointment`, `task`, `data`, `ccda`, `schedule_event`. |
+| `name_contains` | string | no | Case-insensitive substring match on the type's display name (e.g. 'review', 'telehealth', 'office'). |
+| `active_only` | boolean | no | When true (default), restrict to currently active types (is_active and is_visible). Set false to include deprecated or hidden types. |
+| `limit` | integer | no | Maximum results. Defaults to 50. |
+
+**Returns:** Array of objects with `id`, `name`, `category` (NoteTypeCategories), `is_active`, `is_visible`, `is_billable`, `is_sig_required`.
+
+**Backing data model:** `NoteType`.
+
+#### `find_practice_locations`
+
+**Category:** `@config_reads`
+
+List the customer's configured PracticeLocation rows. Returns each location with `id` (the UUID to pass as `practice_location_id` to note-creation tools), `full_name`, `short_name`, `place_of_service_code` (CMS POS code), and `active`. Customer-level config — NOT patient-scoped. Use to resolve a friendly handle ('main clinic', 'downtown office') into the UUID note-write tools need.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `active_only` | boolean | no | When true (default), restrict to active locations. |
+| `name_contains` | string | no | Case-insensitive substring match on full_name (e.g. 'main', 'downtown'). |
+| `limit` | integer | no | Maximum results. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `full_name`, `short_name`, `place_of_service_code`, `active`.
+
+**Backing data model:** `PracticeLocation`.
+
+#### `find_lab_partners`
+
+**Category:** `@config_reads`
+
+List the customer's configured lab partners (LabCorp, Quest, in-house, etc.). Returns each with `id` (UUID to pass as `lab_partner` to `originate_lab_order`), `name`, `active`, and `electronic_ordering_enabled`. Customer-level config — NOT patient-scoped. Step 1 of the order-lab flow: pick a partner here, then call `find_lab_partner_tests(lab_partner_id=<id>)` to discover the orderable tests for that partner.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the partner's name (e.g. 'labcorp', 'quest', 'generic'). |
+| `active_only` | boolean | no | When true (default), restrict to active partners. |
+| `electronic_ordering_only` | boolean | no | When true, restrict to partners that accept electronic orders (filters out paper-only partners). |
+| `limit` | integer | no | Maximum results. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `name`, `active`, `electronic_ordering_enabled`.
+
+**Backing data model:** `LabPartner`.
+
+#### `find_lab_partner_tests`
+
+**Category:** `@config_reads`
+
+Search a lab partner's compendium of orderable tests. Returns each test with `id` (UUID) and `order_code` (the partner's own catalog code) — EITHER value is accepted by `originate_lab_order`'s `tests_order_codes` argument. Also returns `order_name` (display name) and `cpt_code`. Customer-level config — NOT patient-scoped. EXACTLY ONE of `lab_partner_id` or `lab_partner_name` is required to scope the search; without it the result set is empty. Workflow: (1) `find_lab_partners` to choose a partner; (2) `find_lab_partner_tests(lab_partner_id=<id>, search='glucose')` to find tests; (3) `originate_lab_order(lab_partner=<id>, tests_order_codes=[<order_code>, ...])`.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `lab_partner_id` | string | no | UUID of the lab partner whose tests to search — from `find_lab_partners`. Either this or `lab_partner_name`. |
+| `lab_partner_name` | string | no | Case-insensitive exact name of the lab partner — alternative to `lab_partner_id`. Either this or `lab_partner_id`. |
+| `search` | string | no | Case-insensitive substring match across `order_name`, `order_code`, and `keywords` — same shape as the chart-UI autocomplete (e.g. 'glucose', 'CBC', 'lipid'). |
+| `cpt_contains` | string | no | Case-insensitive substring match on the test's CPT code. |
+| `limit` | integer | no | Maximum results. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `order_code`, `order_name`, `cpt_code`.
+
+**Backing data model:** `LabPartnerTest`.
+
+#### `find_medication_statements`
+
+**Category:** `@clinical_reads`
+
+Search the patient's recorded medication statements — patient-reported or self-administered medications (distinct from active prescriptions which `find_medications` covers). Returns each statement with `medication_name`, `start_date` (ISO 8601 or null), `end_date` (ISO 8601 or null), `dose_form`, `dose_route`, `dose_frequency_interval`, and `sig_original_input` (the patient's verbatim sig).
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the medication's first-coding display. |
+| `started_on_or_after` | string (date) | no | ISO 8601 date. Only return statements with start_date >= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `medication_name`, `narrative`, `recorded_at`.
+
+**Backing data model:** `MedicationStatement`.
+
+#### `find_external_events`
+
+**Category:** `@clinical_reads`
+
+Search external healthcare events recorded for the patient — typically HL7 feeds from external systems (ADT, ORM, etc.). Each event has `event_type` (e.g., 'ADT', 'ORM'), `event_datetime` (ISO 8601), `facility_name` (from the linked external visit), and `information_source`. Useful for understanding the patient's encounters outside the EHR. Ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `event_type` | string | no | Filter to a specific event_type (e.g., 'ADT' for admit/discharge/transfer, 'ORM' for orders). Case-insensitive exact match. |
+| `occurred_on_or_after` | string (date) | no | ISO 8601 date. Only return events with event_datetime >= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `event_type`, `event_datetime`, `facility_name`, `information_source`.
+
+**Backing data model:** `ExternalEvent`.
+
+#### `find_prescriptions`
+
+**Category:** `@clinical_reads`
+
+Search the patient's prescription records (actual Rx events — distinct from `find_medications` which surfaces the medication list). Each result has `medication_name`, `status`, `written_date` (ISO 8601), `dispensed_date` (ISO 8601 or null), `end_date` (ISO 8601 or null), `sig_original_input`, `dose_form`, `dose_route`, `dose_frequency_interval`, and `is_refill`. Patient scope is enforced. Defaults to committed prescriptions ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the medication's first-coding display. |
+| `status` | string | no | Filter to a specific prescription status (e.g., 'active', 'completed', 'cancelled'). Case-insensitive. |
+| `written_on_or_after` | string (date) | no | ISO 8601 date. Only return prescriptions with written_date >= this. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `medication_name`, `status`, `written_date`, `dispensed_date`, `quantity_to_dispense`, `days_supply`, `is_refill`, `sig_original_input`.
+
+**Backing data model:** `Prescription`.
+
+#### `find_questionnaire_responses`
+
+**Category:** `@clinical_reads`
+
+Search the patient's completed and in-progress questionnaire responses (Interviews). Each result includes `name`, `progress_status`, `questionnaire_names`, `answered_at` (ISO 8601), and `responses` — an array of per-question answers with the question text, the human-readable selection, and `response_value` (the question option's underlying value string, often numeric for scored instruments like PHQ-9 or Stress). For scored questionnaires `response_value` is what you'd chart or sum. For non-scored / categorical ones it may be text — in that case offer the clinician a numeric conversion before plotting and confirm their interpretation before treating it as a score. Patient scope is enforced; non-committed interviews are excluded.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the interview's name (e.g., 'PHQ', 'depression', 'GAD', 'stress'). |
+| `progress_status` | string | no | Filter to a specific progress_status code (e.g., 'F' for finished/complete, 'S' for started, 'N' for new). Case-insensitive. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `name`, `progress_status`, `questionnaire_names`, `answered_at`, and `responses` (per-question array of `question`, `response_text`, `response_value`).
+
+**Backing data model:** `Interview`.
+
+#### `find_stop_medication_events`
+
+**Category:** `@clinical_reads`
+
+Search records of medications the patient stopped. Each event has `medication_name`, `rationale` (free-text reason for stopping, captured by the clinician), and `stopped_at` (ISO 8601). Useful for understanding why a medication is no longer active. Ordered most-recent first.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name_contains` | string | no | Case-insensitive substring match on the stopped medication's first-coding display. |
+| `rationale_contains` | string | no | Case-insensitive substring match on the rationale text (e.g., 'side effects', 'ineffective', 'allergy'). |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `id`, `medication_name`, `rationale`, `stopped_at`.
+
+**Backing data model:** `StopMedicationEvent`.
+
+#### `find_banner_alerts`
+
+**Category:** `@clinical_reads`
+
+Search the patient's banner alerts (visual flags shown on the chart). Returns each banner's `key`, `narrative`, `intent` (info/warning/alert), `placement` (list), `href` (or null), and `status` (active/inactive). Use this to discover what's already flagged before adding a duplicate, or to find a banner's key for `remove_banner_alert`. Defaults to active banners only.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `narrative_contains` | string | no | Case-insensitive substring match on the banner's narrative text (e.g., 'mammogram', 'INR'). |
+| `intent` | string (enum) | no | Restrict to one visual intent: 'info', 'warning', or 'alert'. One of: `info`, `warning`, `alert`. |
+| `include_inactive` | boolean | no | When true, also return banners with status='inactive' (historical/removed). Default false — active only. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `key`, `narrative`, `intent`, `placement` (array of strings), `href`, `status`.
+
+**Backing data model:** `BannerAlert`.
+
+#### `find_protocol_cards`
+
+**Category:** `@clinical_reads`
+
+Search the patient's protocol cards (clinical decision support surfaces shown on the chart). Each card has a `protocol_key` (pass to `add_or_update_protocol_card` as `card_key` to update it), `title`, `narrative`, `status` (due / satisfied / not_applicable / pending / not_relevant), and `plugin_name` identifying which plugin staged it. Use this to discover what's already flagged before adding a new card, to find prior cards your plugin staged that need a status update, or to inspect cards staged by other plugins for context. Defaults to all statuses; filter to active ones via `active_only=true`.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `title_contains` | string | no | Case-insensitive substring match on the card's title. |
+| `status` | string | no | Restrict to one lifecycle status: 'due', 'satisfied', 'not_applicable', 'pending', 'not_relevant'. |
+| `plugin_name` | string | no | Restrict to cards staged by a specific plugin (exact match). Use to scope find results to your own plugin's cards. |
+| `active_only` | boolean | no | When true, return only cards with status='due' or 'pending'. Default false — return cards in any status. |
+| `limit` | integer | no | Maximum results to return. Defaults to 25. |
+
+**Returns:** Array of objects with `protocol_key`, `title`, `narrative`, `status`, `plugin_name`, `next_review` (ISO 8601 or null), `snoozed`.
+
+**Backing data model:** `ProtocolCurrent`.
+
+#### `get_patient_demographics`
+
+**Category:** `@clinical_reads`
+
+Return basic demographics for the current patient: legal name, preferred name, MRN, date of birth, computed age in years, sex_at_birth, gender_identity, preferred_pronouns, and whether they're marked deceased. Takes no arguments.
+
+**Arguments:** none.
+
+**Returns:** Object with `first_name`, `middle_name`, `last_name`, `preferred_name`, `mrn`, `birth_date`, `age_years`, `sex_at_birth`, `gender_identity`, `preferred_pronouns`, `deceased`.
+
+#### `originate_review_note`
+
+**Category:** `@clinical_writes`
+
+Stage a draft review-category note for the patient with a single Plan command containing the narrative. NEVER commits — the note + plan draft sit unsigned for the clinician to review, edit, and sign. Use when the clinician asks to draft a chart-review note, lab-review note, or similar narrative summary that isn't tied to a live visit. Before calling: (1) `find_note_types(category='review')` to get a `note_type_id`; (2) `find_practice_locations` to get a `practice_location_id`. Patient + requesting-staff come from the agent's scope automatically.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `narrative` | string | yes | The body of the Plan command on the new note. Plain prose, no markdown. This is what becomes the note's primary content. |
+| `note_type_id` | string | yes | UUID of a NoteType row with category='review' — get from `find_note_types(category='review')`. The customer's review note type IDs vary; don't guess. |
+| `practice_location_id` | string | yes | UUID of a PracticeLocation row — get from `find_practice_locations`. The customer's locations vary; don't guess. |
+| `title` | string | no | Optional note title (e.g., 'Lab review — 2026-05-15'). Falls back to the NoteType's default if omitted. |
+| `datetime_of_service` | string (date-time) | no | Optional ISO 8601 datetime. Defaults to now if omitted. Use for back-dated reviews. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: 'plan', committed: false}`. Two effects are bundled: CREATE_NOTE for the review shell and the Plan command originating onto it. Clinician reviews/edits/signs.
+
+**Backing Command:** `PlanCommand`.
+<!-- AUTOGEN:reads END -->
+
+### Writes
+
+Effect tools — each stages a Canvas Effect into the run's accumulator
+that the platform dispatches after `run()` returns. None of them
+commit chart state outright. Task and banner tools take their target
+identifier from the response of a prior `create_*` or `find_*` call;
+the "Returns" line on each tool calls out which fields chain.
+
+<!-- AUTOGEN:writes START -->
+#### `add_banner_alert`
+
+**Category:** `@clinical_alerts`
+
+Surface a banner alert on the patient — visible to anyone viewing the chart. Use to flag clinically meaningful state the clinician should notice on their next visit (e.g., 'overdue mammogram', 'on warfarin — INR last drawn 8 months ago'). Narrative is truncated to 90 chars. Banners persist until removed; don't create duplicates for the same finding. Returns the generated key so the banner can be referenced/removed later.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `narrative` | string | yes | Short banner text — what the clinician should see. Truncated to 90 chars. E.g. 'Overdue colonoscopy — screening interval was 10y.' |
+| `intent` | string (enum) | yes | Visual emphasis. 'info' for neutral context, 'warning' for issues that need attention, 'alert' for safety-critical. One of: `info`, `warning`, `alert`. |
+| `placement` | array of string (enum) | yes | Where the banner appears. Most clinical alerts want ['chart']; add 'timeline' to also surface on the patient timeline. Use 'profile' for identity/demographic flags. |
+| `href` | string | no | Optional URL the banner links to. Use for deep-links to supporting context (e.g., the lab result page). |
+
+**Returns:** `{ok: true, banner_key: <uuid>}` — pass `banner_key` to `remove_banner_alert` later to take the banner down.
+
+**Backing Effect:** `AddBannerAlert`.
+
+#### `remove_banner_alert`
+
+**Category:** `@clinical_alerts`
+
+Remove a previously-staged banner alert from the patient's chart. Takes the banner's `key` — obtained either from a prior `add_banner_alert` call (returned as `banner_key` in the response) or from `find_banner_alerts`. Use when the underlying clinical issue has been addressed (e.g., the overdue screening was completed) and the banner should no longer display.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `banner_key` | string | yes | The banner's key — exactly as returned by add_banner_alert (``banner_key`` in the response) or find_banner_alerts (``key`` in each row). |
+
+**Returns:** `{ok: true}`.
+
+**Backing Effect:** `RemoveBannerAlert`.
+
+#### `create_task`
+
+**Category:** `@task_writes`
+
+Create a follow-up Task for the patient — appears in the clinician's task queue for them to act on later. Use for things the clinician should do but that can't be staged as a chart command (call patient, schedule follow-up visit, review external records). The task is not assigned to a specific user; team/assignee routing happens via the instance's task triage rules. Title is truncated to 200 chars. Returns the generated task_id so it can be referenced later.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | yes | Plain-text task title (truncated to 200 chars). |
+
+**Returns:** `{ok: true, task_id: <uuid>}` — pass `task_id` to `update_task` or `add_task_comment` to close or annotate the task later.
+
+**Backing Effect:** `AddTask`.
+
+#### `update_task`
+
+**Category:** `@task_writes`
+
+Update an existing task — typically to close it (status=COMPLETED), reopen it (status=OPEN), or change its title/due. The task_id must come from a prior `find_tasks` or `create_task` call; this tool does not look tasks up by content. Title is truncated to 200 chars. Only the fields you supply are updated; omitted fields are left as-is.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `task_id` | string | yes | The task's UUID — from a prior find_tasks/create_task call. |
+| `status` | string (enum) | no | New status. 'COMPLETED' marks the task done, 'CLOSED' dismisses it without completion, 'OPEN' reopens. Optional — omit to leave status unchanged. One of: `COMPLETED`, `CLOSED`, `OPEN`. |
+| `title` | string | no | Updated task title (truncated to 200 chars). Optional. |
+| `due_on` | string (date) | no | Updated due date (ISO 8601 YYYY-MM-DD). Optional. |
+
+**Returns:** `{ok: true}`.
+
+**Backing Effect:** `UpdateTask`.
+
+#### `add_task_comment`
+
+**Category:** `@task_writes`
+
+Add a comment to an existing task — use to explain *why* a task was created/closed or to add context the clinician should see when they pick up the task. The task_id must come from a prior find_tasks or create_task call.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `task_id` | string | yes | The task's UUID — from a prior find_tasks/create_task call. |
+| `body` | string | yes | The comment text. Plain text; no markdown. |
+
+**Returns:** `{ok: true}`.
+
+**Backing Effect:** `AddTaskComment`.
+
+#### `add_or_update_protocol_card`
+
+**Category:** `@clinical_alerts`
+
+Stage or update a protocol card on the patient — a clinical decision support surface with title, narrative, and a list of recommended actions the clinician can take. Pass `card_key` to update an existing card (idempotent — call again to refresh narrative/status as the underlying clinical picture changes); omit to create a new one. Status drives visual treatment: 'due' (needs action), 'satisfied' (done), 'not_applicable' (doesn't apply to this patient), 'pending' (in progress), 'not_relevant' (dismissed). Title and narrative are truncated to 200 and 500 chars respectively. Returns the card_key so the same card can be updated later.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | yes | Short card title — what the clinician sees first. Truncated to 200 chars. E.g. 'Diabetes management — A1c overdue'. |
+| `narrative` | string | yes | Body text explaining the clinical context and why this is surfacing now. Truncated to 500 chars. |
+| `status` | string (enum) | no | Card lifecycle status. Defaults to 'due' if omitted. One of: `due`, `satisfied`, `not_applicable`, `pending`, `not_relevant`. |
+| `card_key` | string | no | Stable key identifying the card. Supply the key from a prior call to update that card; omit to create a new one (a UUID is generated). |
+| `recommendations` | array of object | no | Optional recommended actions surfaced beneath the card. Each is an object with `title` (required, what the action is), optional `button` (call-to-action text), optional `href` (link the button opens), and optional `commands` — a list of chart commands the button stages on the open note when clicked. When the clinician clicks the button, the platform stages each originated command as a draft for the clinician to review, edit, and commit. |
+| `due_in` | integer | no | Days from now until the card is 'due' — drives the 'Next due' text the clinician sees on the card. Use positive integers (e.g., 90 for 'recheck in 3 months'). Default -1 means no specific due date. |
+| `can_be_snoozed` | boolean | no | When true, the chart UI shows a snooze affordance on the card so the clinician can temporarily hide it without marking it satisfied. Recommended for cross-visit follow-up cards. Default false. |
+| `feedback_enabled` | boolean | no | When true, the chart UI surfaces a feedback affordance on the card — typically a dismiss / 'not relevant' control. Recommended for agent-generated cards so the clinician has a way to push back when the recommendation doesn't apply. Default false. |
+
+**Returns:** `{ok: true, card_key: <uuid>}` — pass `card_key` back to update the same card on a subsequent run.
+
+**Backing Effect:** `ProtocolCard`.
+
+#### `originate_plan`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Plan command on the patient's current open note for the clinician to review, edit, and commit. NEVER commits — the clinician sees the draft in the chart and decides whether to keep it. Use when the conversation has produced a concise plan paragraph worth surfacing on the note.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `narrative` | string | yes | The plan text. Plain prose; no markdown. Keep it concise — this becomes the body of the Plan command on the note. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `PlanCommand`.
+
+#### `originate_prescribe_medication`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Prescribe command on the patient's current open note for the clinician to review, edit, and commit. NEVER commits — the clinician sees the draft in the chart and decides whether to send it. Use only when the clinician explicitly asks to prescribe.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `fdb_code` | string | no | FDB code identifying the medication. If unknown, omit; the clinician will fill it in when reviewing the draft. |
+| `sig` | string | yes | Patient instructions (e.g. 'Take 1 tablet by mouth daily'). |
+| `indications_icd10` | array of string | no | ICD-10 codes justifying the prescription (max 2). Optional. |
+| `days_supply` | integer | no | Days supply for the prescription. Optional. |
+| `refills` | integer | no | Refills (0 = no refills). Optional. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `PrescribeCommand`.
+
+#### `originate_lab_order`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Lab Order command on the patient's current open note for the clinician to review and commit. NEVER commits. Use when the clinician asks to order labs.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `tests_order_codes` | array of string | yes | Order codes for the tests to include. At least one required. |
+| `diagnosis_codes` | array of string | no | ICD-10 codes for diagnoses justifying the order. |
+| `lab_partner` | string | no | Lab partner UUID or name. Optional; the clinician can fill it in when reviewing. |
+| `comment` | string | no | Optional free-text instructions to the lab. |
+| `fasting_required` | boolean | no | Whether the patient needs to fast before collection. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `LabOrderCommand`.
+
+#### `originate_diagnose_condition`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Diagnose command on the patient's current open note for the clinician to review and commit. NEVER commits. Use when the clinician wants to capture a new diagnosis.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `icd10_code` | string | yes | ICD-10 code for the condition (e.g. 'E11.9'). |
+| `today_assessment` | string | no | Today's assessment narrative for this diagnosis. |
+| `background` | string | no | Optional background/context for the diagnosis. |
+| `approximate_date_of_onset` | string (date) | no | ISO 8601 date of approximate onset. Optional. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `DiagnoseCommand`.
+
+#### `originate_goal`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Goal command on the patient's current open note for the clinician to review and commit. NEVER commits. Use to capture a discrete clinical goal (e.g., 'A1c < 7.0 within 6 months', 'walking 30 minutes 5x/week'). The narrative goes in goal_statement.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `goal_statement` | string | yes | Plain-text statement of the goal. |
+| `priority` | string (enum) | no | Goal priority. Optional. One of: `high-priority`, `medium-priority`, `low-priority`. |
+| `achievement_status` | string (enum) | no | Current achievement status. Default 'in-progress' if omitted. One of: `in-progress`, `improving`, `worsening`, `no-change`, `achieved`, `sustaining`, `not-achieved`, `no-progress`, `not-attainable`. |
+| `due_date` | string (date) | no | ISO 8601 target date for the goal. Optional. |
+| `progress` | string | no | Optional free-text note about current progress. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `GoalCommand`.
+
+#### `originate_assessment`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Assess command on the patient's current open note — the clinician's assessment of one of the patient's existing conditions ('how is this condition doing today'). NEVER commits. Requires the condition_id from a prior `find_conditions` call.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `condition_id` | string | yes | UUID of the condition being assessed — from a prior find_conditions call (the row's `id` field). |
+| `status` | string (enum) | no | Status of the condition today relative to its prior state. One of: `improved`, `stable`, `deteriorated`. |
+| `narrative` | string | no | Today's assessment narrative for this condition. |
+| `background` | string | no | Optional background/context. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `AssessCommand`.
+
+#### `originate_follow_up`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Follow-Up command on the patient's current open note to schedule a return visit. NEVER commits. Use when the clinician wants to plan a follow-up appointment (e.g., 'recheck in 2 weeks').
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `requested_date` | string (date) | no | ISO 8601 target date for the follow-up. |
+| `comment` | string | no | Free-text reason for the follow-up (visible to scheduling). E.g., 'recheck BP after med adjustment'. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `FollowUpCommand`.
+
+#### `originate_stop_medication`
+
+**Category:** `@clinical_writes`
+
+Stage a draft Stop-Medication command on the patient's current open note to discontinue an active medication. NEVER commits. Requires medication_id from a prior `find_medications` call. Use when the clinician decides to stop a med (side effects, ineffective, completed course).
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `medication_id` | string | yes | UUID of the medication to stop — from a prior find_medications call (the row's `id` field). |
+| `rationale` | string | no | Reason for stopping (e.g., 'side effects', 'completed course', 'ineffective'). Visible to anyone reviewing the chart. |
+
+**Returns:** `{ok: true, note_id: <uuid>, command: '<command_key>', committed: false}`. Never commits — the clinician reviews the draft in the chart and decides whether to commit.
+
+**Backing Command:** `StopMedicationCommand`.
+
+#### `originate_message`
+
+**Category:** `@message_writes`
+
+Stage a draft message from the requesting staff to this patient for the staff to review, edit, and send. NEVER sends — drafts land in the staff's outbox; the clinician hits Send. Use when the clinician explicitly asks to reply to or message the patient (e.g., 'draft a reply about her A1c', 'message the patient about their lab results'). Pull recent inbound messages via `find_messages(from_patient_only=true)` first so the draft reflects the actual conversation. Keep drafts patient-readable: plain English, short sentences, no jargon unless the clinician asked for a technical tone.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `content` | string | yes | The message body the patient will read. Plain text only — no markdown headings or HTML. Address the patient directly. Sign off as the staff member if appropriate; the patient sees the sender's name on the message header either way. |
+
+**Returns:** `{ok: true, status: 'draft'}`. The draft sits unsent in the staff's outbox; the clinician reviews and decides whether to send.
+
+**Backing Effect:** `Message`.
+<!-- AUTOGEN:writes END -->


### PR DESCRIPTION
## Summary

First public-facing documentation for the Agent Runner Framework. Pairs with the implementation work on canvas-medical/canvas-plugins#1713 and canvas-medical/canvas#19057.

Adds one top-level page (`/sdk/agents/`) and seven subpages, wired into the SDK menu under a new \`sdk_agents\` group.

## Pages

| Page | Covers |
|---|---|
| [Overview](/sdk/agents/) | What agents are vs handlers, when to reach for one, the dispatch architecture (with an ASCII diagram), the platform/plugin responsibility split, credentials, manifest declaration. Marked "preview" up top. |
| [Quick Start](/sdk/agents-quick-start/) | Full working \`ChartSummary\`-shaped example in ~50 lines: tool registry, agent class, trigger handler, manifest entry, install. |
| [Lifecycle](/sdk/agents-lifecycle/) | \`AgentPlugin\` contract, the 12-step platform-driven run order, three abstract methods + four optional hooks, concurrency / \`scope_key\` shaping. |
| [Managing State](/sdk/agents-managing-state/) | Three persistence patterns (stateless / snapshot / event-sourced) with reference-plugin code samples, trade-offs, storage options. |
| [Tools](/sdk/agents-tools/) | Read vs effect tools, \`ToolRegistry\` mechanics, executor signature, manifest-driven permission filtering with the platform-side scoping security story, design tips, full \`standard_tools\` catalog. |
| [Prompts](/sdk/agents-prompts/) | System vs in-dialogue prompts in a clinical setting, what belongs in each, boundary patterns that hold under pressure, iteration practices. |
| [Testing](/sdk/agents-testing/) | Patterns for unit-testing agents and tools without real provider calls. Canned \`_response\` / \`_tool_use\` / \`_text\` helpers; simulating manifest-scoping; integration testing through the plugin-runner. |
| [Auditing](/sdk/agents-auditing/) | The platform/plugin audit split: platform owns billing/cost/structural lifecycle metadata; plugin owns intent/rationale/decision facts. Retention as a deliberate decision with a platform-enforced ceiling (coming soon). \`AgentRunLog\` reference pattern via lifecycle hooks. |

## Notes for review

- The framework is **preview**, called out on the overview page. Forward-compat-coming features (LLM gateway service, \`AllTurnsState\` / \`SlidingWindowState\` / \`SummarizingState\` state helpers, manifest-declared retention) are mentioned inline as "Coming soon" rather than documented as if they exist today. Plugin authors get a real picture of what they can build with vs what's on the way.
- The auditing page articulates the platform-vs-plugin audit split we want to communicate to plugin authors: platform owns the *skeleton* (run lifecycle metadata, cost, tokens, tool-call envelope; stable schemas, predictable retention, needed for billing/abuse regardless of plugin behavior); plugin owns the *meaning* (rationale, grounding facts, decision content). Retention is plugin-set but platform-capped.
- All code samples are runnable shapes from the reference plugin (\`example-plugins/agent_runner_poc\` in canvas-plugins#1713). No invented APIs.

## Test plan

- [ ] Local Jekyll build renders all eight pages without errors.
- [ ] Cross-links between pages resolve (each page links to the others where relevant).
- [ ] Menu entry "Agent Runner Framework" expands to the seven subpages in order: Quick Start → Lifecycle → Managing State → Tools → Prompts → Testing → Auditing.
- [ ] Code samples copy-paste cleanly (no extra prose markers in code fences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)