### PR TITLE
Add Instruction data model docs (KOALA-5567)

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -1004,6 +1004,9 @@ data_module:
   - title: "Immunization"
     url: /sdk/data-immunization/
     description: A record of a vaccination that is being administered to a patient, either now, in the past, or in the future.
+  - title: "Instruction"
+    url: /sdk/data-instruction/
+    description: An Instruct command committed in a patient's note — clinical guidance such as cessation counseling or dietary instructions.
   - title: "IntegrationTask"
     url: /sdk/data-integration-task/
     description: Incoming documents that need processing, including faxes, uploads, and portal submissions.

--- a/collections/_sdk/data/instruction.md
+++ b/collections/_sdk/data/instruction.md
@@ -1,0 +1,137 @@
+---
+title: "Instruction"
+slug: "data-instruction"
+excerpt: "Canvas SDK Instruction"
+hidden: false
+---
+
+## Introduction
+
+The `Instruction` model represents an `Instruct` command committed in a patient's note — for example, "cessation of smoking" counseling, dietary instructions, or any other piece of clinical guidance recorded as an Instruct command.
+
+Querying `Instruction` from a plugin is the recommended way to ask "has this patient been given an instruction in this value set?" — for example, when computing quality measures that look for tobacco cessation counseling or dialysis education.
+
+## Basic usage
+
+To get an instruction by identifier, use the `get` method on the `Instruction` model manager:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+
+instruction = Instruction.objects.get(id="b80b1cdc-2e6a-4aca-90cc-ebc02e683f35")
+```
+
+If you have a patient object, the instructions for a patient can be accessed with the `instructions` attribute on a `Patient` object:
+
+```python
+from canvas_sdk.v1.data.patient import Patient
+
+patient = Patient.objects.get(id="1eed3ea2a8d546a1b681a2a45de1d790")
+instructions = patient.instructions.all()
+```
+
+If you have a patient ID, you can get the instructions for the patient with the `for_patient` method on the `Instruction` model manager:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+
+patient_id = "1eed3ea2a8d546a1b681a2a45de1d790"
+instructions = Instruction.objects.for_patient(patient_id)
+```
+
+## Codings
+
+The codings for an instruction can be accessed with the `codings` attribute on an `Instruction` object:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+from logger import log
+
+instruction = Instruction.objects.get(id="b80b1cdc-2e6a-4aca-90cc-ebc02e683f35")
+
+for coding in instruction.codings.all():
+    log.info(f"system:  {coding.system}")
+    log.info(f"code:    {coding.code}")
+    log.info(f"display: {coding.display}")
+```
+
+Instruct commands originated through the SDK use either the SNOMED CT code system or an internal "unstructured" system for free-text instructions. See the [InstructCommand](/sdk/commands/#instructcommand) effect for the write-side details.
+
+## Committed instructions
+
+The `committed` method returns instructions whose underlying command has been committed and not entered in error:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+
+committed_instructions = Instruction.objects.committed()
+```
+
+## Filtering
+
+Instructions can be filtered by any attribute that exists on the model.
+
+Filtering for instructions is done with the `filter` method on the `Instruction` model manager.
+
+### By attribute
+
+Specify an attribute with `filter` to filter by that attribute:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+
+instructions = Instruction.objects.filter(note__id="2c91b0d8-7b9d-4ef1-89e2-1f9a3a8a2b14")
+```
+
+### By ValueSet
+
+Filtering by ValueSet works a little differently. The `find` method on the model manager is used to perform `ValueSet` filtering:
+
+```python
+from canvas_sdk.v1.data.instruction import Instruction
+from canvas_sdk.value_set.v2018.intervention import TobaccoUseCessationCounseling
+
+cessation_counseling = (
+    Instruction.objects
+    .for_patient("1eed3ea2a8d546a1b681a2a45de1d790")
+    .committed()
+    .find(TobaccoUseCessationCounseling)
+)
+```
+
+`find` joins through the `codings` reverse relation and filters on `(system, code)` pairs from the value set, so it composes naturally with `for_patient` and `committed`.
+
+## Attributes
+
+### Instruction
+
+| Field Name       | Type                                        |
+|------------------|---------------------------------------------|
+| id               | UUID                                        |
+| dbid             | Integer                                     |
+| created          | DateTime                                    |
+| modified         | DateTime                                    |
+| originator       | [CanvasUser](/sdk/data-canvasuser)          |
+| committer        | [CanvasUser](/sdk/data-canvasuser)          |
+| entered_in_error | [CanvasUser](/sdk/data-canvasuser)          |
+| deleted          | Boolean                                     |
+| patient          | [Patient](/sdk/data-patient/#patient)       |
+| note             | [Note](/sdk/data-note/#note)                |
+| narrative        | String                                      |
+| codings          | [InstructionCoding](#instructioncoding)[]   |
+
+### InstructionCoding
+
+| Field Name    | Type                        |
+|---------------|-----------------------------|
+| dbid          | Integer                     |
+| system        | String                      |
+| version       | String                      |
+| code          | String                      |
+| display       | String                      |
+| user_selected | Boolean                     |
+| instruction   | [Instruction](#instruction) |
+
+<br/>
+<br/>
+<br/>


### PR DESCRIPTION
**Jira:** [KOALA-5567](https://canvasmedical.atlassian.net/browse/KOALA-5567)

## Summary

Adds a new SDK reference page for the `Instruction` data model (`canvas_sdk.v1.data.instruction`), which lets plugins query committed `Instruct` commands directly instead of sniffing `Command.data` JSON.

- New page: `collections/_sdk/data/instruction.md`, modeled on the existing `Condition` page plus the `.committed()` section pattern from `Prescription`.
- Covers basic usage (`get`, `patient.instructions`, `for_patient`), codings access, the `.committed()` filter, attribute filtering, and a worked `find(value_set)` example using `TobaccoUseCessationCounseling`.
- Full attribute tables for both `Instruction` and `InstructionCoding`.
- Menu entry added in `_data/menus.yml` between `Immunization` and `IntegrationTask`.

## Why

This is the docs companion to the SDK model added in [canvas-plugins#1722](https://github.com/canvas-medical/canvas-plugins/pull/1722), itself the read-side closure of [Medical-Software-Foundation/canvas#270](https://github.com/Medical-Software-Foundation/canvas/pull/270) follow-up #3.

## Related PRs

- **SDK model**: [canvas-medical/canvas-plugins#1722](https://github.com/canvas-medical/canvas-plugins/pull/1722) — `Instruction` and `InstructionCoding` in `canvas_sdk.v1.data`.
- **home-app database views**: [canvas-medical/canvas#19076](https://github.com/canvas-medical/canvas/pull/19076) — `api_instruction` and `api_instructioncoding` SDK views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-5567]: https://canvasmedical.atlassian.net/browse/KOALA-5567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ