### PR TITLE
docs: document Constance: Config admin section + AD-role requirement

### DIFF
--- a/collections/_documentation/constance-config.md
+++ b/collections/_documentation/constance-config.md
@@ -1,0 +1,36 @@
+---
+title: "Constance: Config (runtime configuration)"
+layout: documentation
+---
+
+Several Canvas features are toggled per-instance via **Constance: Config**, a section of the Django admin interface that exposes runtime-tweakable settings. Release notes will sometimes reference one of these settings directly &mdash; for example, [`ENABLE_CANVAS_CHAT`](/release-notes/config-canvas-chat/), `COVERAGE_DEFAULT_QR_SCAN_MODAL`, `NOTE_BODY_TAB_LABEL`, or `ALLOW_PATIENT_ADDRESS_ZIP4_INTERNATIONAL` &mdash; without explaining where the setting lives or who can change it. This page covers both.
+
+## Where to find Constance: Config
+
+In your Canvas admin, **Settings &rarr; Constance &rarr; Config**. The **Constance** section appears in the left sidebar of the admin index above similarly-grouped admin apps. Inside, find the setting by name (settings are listed alphabetically) and edit the **Value** column. Boolean settings show a checkbox; string and numeric settings show a text input. Click `SAVE` at the bottom to apply.
+
+Changes take effect immediately for the instance you're editing &mdash; no restart, no deploy. The setting is per-instance, so changing it on a dev instance does not affect production.
+
+## Who can access it
+
+Constance: Config is admin-level functionality. **Staff who hold the "Administrative Developer" (AD) role on your Canvas instance get access to the Constance section in admin.** Standard staff accounts that have not been granted the AD role will not see the Constance section in the admin sidebar.
+
+A small number of settings within Constance: Config are reserved for Canvas Medical engineering and will not appear even to AD-role staff. These are typically settings that govern infrastructure-level behavior (e.g. service endpoint overrides, integration credentials, internal feature flags Canvas is still validating). If a release note references a setting and you cannot see it in your admin even after confirming you hold the AD role, that's the most likely reason; contact [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} to request the change on your behalf.
+
+## Granting the Administrative Developer role
+
+If you need a user to be able to change Constance settings:
+
+1. **An existing administrator at your instance** can grant the AD role to another staff member via the usual staff role management flow (Settings &rarr; Staff &rarr; select the staff member &rarr; assign the **Administrative Developer** role).
+2. **If no one on your team currently has the AD role**, contact [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} and they can assign it on your behalf.
+
+{% include alert.html type="warning" content="<b>The Administrative Developer role is broad.</b> It exposes runtime configuration that affects the whole instance, plus other admin surfaces beyond Constance. Grant it deliberately, only to the people who need to administer instance-wide settings." %}
+
+## Why a setting may not appear
+
+If a release note mentions a Constance setting that you do not see in **Constance: Config**, the most common reasons are:
+
+- **Your account does not hold the Administrative Developer role.** Confirm this first &mdash; the entire Constance section is hidden, not just the missing setting.
+- **The setting is root-restricted.** A small set of Constance settings is reserved for Canvas Medical engineering and will not appear even to AD-role staff (see above). If you need such a setting changed, open a support ticket.
+- **The setting hasn't shipped to your instance yet.** Constance settings are added in code; an instance that's behind on releases will not show settings added in a newer version. Check the [Release Notes](/release-notes/) for the version that introduced the setting and confirm your instance is on or past it.
+- **You're looking at the wrong instance.** Settings are per-instance; a setting flipped on production will not show as changed on a dev instance and vice versa.

--- a/collections/_release-notes/2025-04-07-config-canvas-chat.md
+++ b/collections/_release-notes/2025-04-07-config-canvas-chat.md
@@ -5,4 +5,4 @@ layout: productupdates
 date: 2025-04-07
 ---
 
-A new constance config ENABLE_CANVAS_CHAT allows organizations to enable or disable Canvas Chat for their EMR instance. By default, the setting is set to TRUE.
+A new constance config ENABLE_CANVAS_CHAT allows organizations to enable or disable Canvas Chat for their EMR instance. By default, the setting is set to TRUE. See [Constance: Config (runtime configuration)](/documentation/constance-config/) for where to find this setting in the admin and which role can change it.


### PR DESCRIPTION
## Summary

This PR adds a new `_documentation/constance-config.md` page covering:

- Where Constance: Config lives in the admin (Settings &rarr; Constance &rarr; Config) and how to edit a setting
- That access is granted by the **Administrative Developer (AD)** role &mdash; not django superuser
- That a subset of settings remain root-restricted to Canvas Medical engineering
- How an instance admin grants the AD role, with a fallback to support if no one on the team has it
- The four common reasons a setting may not appear (role, root-restricted, not yet shipped, wrong instance)

The 2025-04-07 canvas-chat release note now links to this page so future release notes that touch a Constance setting have a single canonical place to point.

Sent via Claude on Beau's behalf.

@bexport-gh, @rmagier1 please check the "root-restricted carve-out" framing &mdash; happy to revise if there's a cleaner way to describe which settings stay out of AD reach

Do not merge until docs-team review.