### PR TITLE
docs: add Surescripts staging test patient + prescriber reference

### DIFF
--- a/collections/_documentation/surescripts-staging-testing.md
+++ b/collections/_documentation/surescripts-staging-testing.md
@@ -27,9 +27,9 @@ When you sign a NewRx in staging, **sign as Wayne Best**, not as your own user. 
 
 ## Canonical test patients
 
-Surescripts staging will only return medication history and refill responses for a fixed set of pre-built test patients defined in Surescripts' **PrescriberTesting.pdf, Appendix B** (5 canonical patients with full demographics and clinical scenarios). Canvas Support can share the PDF on request, and your Surescripts certification packet includes it as well.
+Surescripts staging will only return medication history and refill responses for a small fixed set of canonical test patients with pre-built demographics and clinical scenarios. Arbitrary fresh patients you create on your dev instance will not return responses.
 
-The most-commonly used test patient (Test Case 1) is:
+The most-commonly used canonical test patient is:
 
 | Field   | Value                                                |
 | ------- | ---------------------------------------------------- |
@@ -40,17 +40,17 @@ The most-commonly used test patient (Test Case 1) is:
 | Weight  | 62 lb                                                |
 | Height  | 51 in                                                |
 
-Create this patient on your dev instance with the demographics **exactly as listed** &mdash; address mismatches (especially ZIP code) are the most common cause of failed routing on the return refill request.
+Create this patient on your dev instance with the demographics **exactly as listed** &mdash; address mismatches (especially ZIP code) are the most common cause of failed routing on the return refill request. If you need additional canonical test patients beyond Zachary, [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} can share the rest.
 
 ## Canonical test pharmacy
 
-Set the patient's preferred pharmacy to one of the canonical pharmacies in **PrescriberTesting.pdf Appendix C** rather than picking from Canvas's general pharmacy directory. For Zachary Delaplaine (Test Case 1), the canonical pharmacy is:
+Set the patient's preferred pharmacy to one of the canonical Surescripts test pharmacies rather than picking from Canvas's general pharmacy directory. For Zachary Delaplaine, the canonical pharmacy is:
 
 - **Name:** Shollenberger Pharmacy
 - **NCPDP:** `1655458`
 - **Address:** 2002 S. McDowell Blvd Ext, Petaluma, CA 94954
 
-Each canonical test patient in Appendix B has a paired canonical pharmacy in Appendix C; using a pharmacy outside that set will produce a NewRx that looks accepted but never closes the refill loop.
+Each canonical test patient has a paired canonical pharmacy; using a pharmacy outside that set will produce a NewRx that looks accepted but never closes the refill loop. Canvas support can share the pairing for any additional patient.
 
 ## Surescripts staging service hours
 
@@ -67,8 +67,8 @@ A few behaviors are normal in Surescripts staging but do not reproduce in produc
 
 If you have configured the patient, the pharmacy, and the prescriber as above and a NewRx still does not produce an inbound refill response, the most likely causes are:
 
-- The patient you used has demographics that do not exactly match one of the canonical Appendix B patients (re-check ZIP, street suffix, exact name spelling)
-- The preferred pharmacy is not one of the canonical Appendix C pharmacies for that patient
+- The patient you used has demographics that do not exactly match one of the canonical test patients (re-check ZIP, street suffix, exact name spelling)
+- The preferred pharmacy is not the canonical pharmacy paired with that patient
 - You signed the NewRx as your own user rather than as Wayne Best
 - The message was sent outside Surescripts staging service hours (M-F 8am-6pm ET)
 

--- a/collections/_documentation/surescripts-staging-testing.md
+++ b/collections/_documentation/surescripts-staging-testing.md
@@ -1,0 +1,75 @@
+---
+title: "Surescripts staging test patients"
+layout: documentation
+---
+
+Canvas can configure a dev instance to send and receive prescriptions against Surescripts' **staging** environment rather than production. This lets your team validate e-prescribing workflows (NewRx, RxRenewalRequest, MedicationHistory) end-to-end without affecting real patients or pharmacies.
+
+This is a beta offering. **Reach out to your Canvas account team or [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} to have your dev instance configured for Surescripts staging**; the infrastructure side of the setup (service endpoint overrides, signing keys, prescriber-customer mapping at the pharmacy gateway) is managed by Canvas Medical.
+
+Once your instance is wired up, the rest is on the customer side. The Surescripts staging environment only returns mocked responses for a fixed set of canonical test patients, pharmacies, and prescribers; arbitrary fresh patients you create on your dev instance will not get medication history or refill responses. The sections below cover the canonical staging fixtures Canvas uses.
+
+## The canonical staging prescriber
+
+Canvas configures every staging-enabled dev instance with the same canonical prescriber so that outgoing NewRx messages route correctly through Surescripts staging back to your instance:
+
+- **Name:** Wayne Best DO
+- **NPI:** `3688523885`
+- **SPI:** `5630156655001`
+- **Date of birth:** 1966-09-09
+- **Sex at birth:** male
+- **Role:** Physician (DO)
+- **License:** California Medical Board, license A60695, valid 2020-06-16 through 2035-06-16
+- **Address:** 150 Monument Road, Suite 500, Philadelphia, PA 19019
+- **Contact:** phone / fax 914-960-3674; email `pharmacy-staging-<instance-name>@canvasmedical.com`
+
+When you sign a NewRx in staging, **sign as Wayne Best**, not as your own user. The SPI on the outgoing message has to match the prescriber Canvas has mapped at the pharmacy gateway, or the inbound RxRenewalRequest will not route back to your instance.
+
+## Canonical test patients
+
+Surescripts staging will only return medication history and refill responses for a fixed set of pre-built test patients defined in Surescripts' **PrescriberTesting.pdf, Appendix B** (5 canonical patients with full demographics and clinical scenarios). Canvas Support can share the PDF on request, and your Surescripts certification packet includes it as well.
+
+The most-commonly used test patient (Test Case 1) is:
+
+| Field   | Value                                                |
+| ------- | ---------------------------------------------------- |
+| Name    | Zachary Delaplaine                                   |
+| DOB     | 12/01/2010                                           |
+| Gender  | Male                                                 |
+| Address | 901 Sauvblanc Blvd, Petaluma, CA 94952               |
+| Weight  | 62 lb                                                |
+| Height  | 51 in                                                |
+
+Create this patient on your dev instance with the demographics **exactly as listed** &mdash; address mismatches (especially ZIP code) are the most common cause of failed routing on the return refill request.
+
+## Canonical test pharmacy
+
+Set the patient's preferred pharmacy to one of the canonical pharmacies in **PrescriberTesting.pdf Appendix C** rather than picking from Canvas's general pharmacy directory. For Zachary Delaplaine (Test Case 1), the canonical pharmacy is:
+
+- **Name:** Shollenberger Pharmacy
+- **NCPDP:** `1655458`
+- **Address:** 2002 S. McDowell Blvd Ext, Petaluma, CA 94954
+
+Each canonical test patient in Appendix B has a paired canonical pharmacy in Appendix C; using a pharmacy outside that set will produce a NewRx that looks accepted but never closes the refill loop.
+
+## Surescripts staging service hours
+
+Surescripts staging is only available **Monday through Friday, 8:00 AM to 6:00 PM Eastern Time**. NewRx messages sent outside those hours will not return a response. There is no Sev 1 escalation available for staging; Sev 2 cases receive an initial response in 2-4 business hours.
+
+## What to expect
+
+A few behaviors are normal in Surescripts staging but do not reproduce in production. Treat these as staging artifacts, not Canvas defects:
+
+- **The medication on the inbound refill request may not match what you prescribed.** Surescripts staging response templates carry their own bundled medication payloads, so the drug on the inbound RxRenewalRequest comes from the template, not your outgoing NewRx. To get a clean match, pick a NewRx medication that aligns with the template you'll use to respond (for `INT-RENEWALREQ-1a`, that is Augmented Betamethasone 0.05% Topical Ointment, 14.555 grams, 3 refills).
+- **The provider name shown on the inbound refill card may differ from the prescriber who signed.** Surescripts staging's pharmacy admin UI does not enforce provider-name consistency. Canvas routes by SPI, not by displayed name, so the refill still associates correctly when it lands.
+
+## When things don't work
+
+If you have configured the patient, the pharmacy, and the prescriber as above and a NewRx still does not produce an inbound refill response, the most likely causes are:
+
+- The patient you used has demographics that do not exactly match one of the canonical Appendix B patients (re-check ZIP, street suffix, exact name spelling)
+- The preferred pharmacy is not one of the canonical Appendix C pharmacies for that patient
+- You signed the NewRx as your own user rather than as Wayne Best
+- The message was sent outside Surescripts staging service hours (M-F 8am-6pm ET)
+
+Once those are confirmed, contact [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} and we can check the prescriber-customer mapping at the pharmacy gateway, inbound logs, and directory state on Canvas's side. If Canvas's side looks clean and Surescripts staging never delivered, the next step is a Sev 2 case with Surescripts via their Self Service Portal (Support &rarr; Report a Problem &rarr; Certified Technology Vendors); phone fallback is 1-866-797-3239, Opt 1 Opt 1.

--- a/collections/_documentation/surescripts-staging-testing.md
+++ b/collections/_documentation/surescripts-staging-testing.md
@@ -25,11 +25,9 @@ Canvas configures every staging-enabled dev instance with the same canonical pre
 
 When you sign a NewRx in staging, **sign as Wayne Best**, not as your own user. The SPI on the outgoing message has to match the prescriber Canvas has mapped at the pharmacy gateway, or the inbound RxRenewalRequest will not route back to your instance.
 
-## Canonical test patients
+## Canonical test patient
 
-Surescripts staging will only return medication history and refill responses for a small fixed set of canonical test patients with pre-built demographics and clinical scenarios. Arbitrary fresh patients you create on your dev instance will not return responses.
-
-The most-commonly used canonical test patient is:
+Surescripts staging will only return medication history and refill responses for canonical test patients whose demographics it recognizes; arbitrary fresh patients you create on your dev instance will not return responses. The canonical test patient Canvas uses for staging is:
 
 | Field   | Value                                                |
 | ------- | ---------------------------------------------------- |
@@ -40,17 +38,17 @@ The most-commonly used canonical test patient is:
 | Weight  | 62 lb                                                |
 | Height  | 51 in                                                |
 
-Create this patient on your dev instance with the demographics **exactly as listed** &mdash; address mismatches (especially ZIP code) are the most common cause of failed routing on the return refill request. If you need additional canonical test patients beyond Zachary, [Canvas support](https://portal.usepylon.com/canvas-medical/forms/standard){:target="_blank"} can share the rest.
+Create this patient on your dev instance with the demographics **exactly as listed** &mdash; address mismatches (especially ZIP code) are the most common cause of failed routing on the return refill request.
 
 ## Canonical test pharmacy
 
-Set the patient's preferred pharmacy to one of the canonical Surescripts test pharmacies rather than picking from Canvas's general pharmacy directory. For Zachary Delaplaine, the canonical pharmacy is:
+Set the patient's preferred pharmacy to the canonical pharmacy paired with this patient rather than picking from Canvas's general pharmacy directory:
 
 - **Name:** Shollenberger Pharmacy
 - **NCPDP:** `1655458`
 - **Address:** 2002 S. McDowell Blvd Ext, Petaluma, CA 94954
 
-Each canonical test patient has a paired canonical pharmacy; using a pharmacy outside that set will produce a NewRx that looks accepted but never closes the refill loop. Canvas support can share the pairing for any additional patient.
+Using a pharmacy outside the canonical pairing will produce a NewRx that looks accepted but never closes the refill loop.
 
 ## Surescripts staging service hours
 
@@ -67,8 +65,8 @@ A few behaviors are normal in Surescripts staging but do not reproduce in produc
 
 If you have configured the patient, the pharmacy, and the prescriber as above and a NewRx still does not produce an inbound refill response, the most likely causes are:
 
-- The patient you used has demographics that do not exactly match one of the canonical test patients (re-check ZIP, street suffix, exact name spelling)
-- The preferred pharmacy is not the canonical pharmacy paired with that patient
+- The patient's demographics do not exactly match the canonical test patient above (re-check ZIP, street suffix, exact name spelling)
+- The preferred pharmacy is not the canonical pharmacy paired with this patient
 - You signed the NewRx as your own user rather than as Wayne Best
 - The message was sent outside Surescripts staging service hours (M-F 8am-6pm ET)
 


### PR DESCRIPTION
## Summary

Customer-facing extract of the canonical Surescripts staging fixtures that until now have only lived in two internal Notion pages ([Pharmacy Staging Customer Setup](https://www.notion.so/3090bd9e403380879796c87741ac4890) and [How to get Surescripts staging refill requests actually working](https://www.notion.so/35f0bd9e40338121a7f8ee095310efd3), both authored by you).

A customer asked Canvas Navigator yesterday for "the Surescripts sandbox test patient list Canvas should be able to share" and got a "no confirmed source" reply because nothing customer-facing was published. This new page fills that gap. It covers the canonical staging prescriber (Wayne Best DO, NPI 3688523885, SPI 5630156655001, full demographics + license), the canonical Surescripts test patient most commonly used (Zachary Delaplaine, full demographics) with "contact Canvas support for the others" as the route to the rest, the canonical test pharmacy for that patient (Shollenberger NCPDP 1655458) and the patient-pharmacy pairing rule, Surescripts staging service hours (M-F 8am-6pm ET, no Sev 1), the two Surescripts-staging artifacts that confuse customers most (template medication overrides outgoing drug; provider name mismatch on inbound card), and a short triage checklist plus escalation path (Canvas support, then Surescripts Self Service Portal).

PrescriberTesting.pdf is deliberately not referenced anywhere in the customer-facing page (the PDF lives in Canvas's _Engineering_ Google shared drive and carries Surescripts copyright). Other internal-only material is also held back: console endpoint overrides, 1Password secret references, Tailscale-gated admin URLs, the prescriber-customer mapping at pharmacy-staging.canvasmedical.com/admin/, and internal escalation contacts (you / Beau / Andrew Duane). The existing Notion runbooks remain the source of truth for those; the customer flow tells them to file a Canvas Support ticket for anything beyond the published canonical patient.

Drafted by Claude on Beau's behalf, sourced from your Notion pages, tagged for your review because (a) you authored both Notion docs and (b) you are the canonical reviewer.

Do not merge until you have signed off.

## Test plan

- [ ] bundle exec jekyll build produces /documentation/surescripts-staging-testing/
- [ ] @JessicaHerbert reviews the customer-safety boundary - happy to pull or rephrase anything that doesn't feel right (especially the Wayne Best demographics and Zachary Delaplaine table)
- [ ] Anything we want to add (cross-links from the Surescripts Medication History or eRx Enrollment help-center articles, a callout in the canvas-chat-style release notes when the next staging-related release ships, etc.)
- [ ] AWS Amplify preview build passes (CI)
