### PR TITLE
feat: add application notification badges

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -796,6 +796,9 @@ effects_module:
   - title: "Appointments"
     url: /sdk/effect-notes/#appointment-effect
     description: Create, update, and cancel patient appointments.
+  - title: "Application Notification Badge"
+    url: /sdk/effect-application-notification-badge/
+    description: Display and update a notification badge count on an application icon.
   - title: "Banner Alerts"
     url: /sdk/effect-banner-alerts/
     description: Contextual information in a patient's chart.

--- a/collections/_sdk/effects/application_notification_badge.md
+++ b/collections/_sdk/effects/application_notification_badge.md
@@ -1,0 +1,113 @@
+---
+title: "Application Notification Badge"
+slug: "effect-application-notification-badge"
+excerpt: "Display and update a notification badge count on an application icon."
+hidden: false
+---
+
+Notification badges let your plugin surface a count on an
+[application](/sdk/handlers-applications/) icon — the small number that
+indicates, for example, how many unread items are waiting. Badges appear on the
+application icon both in the app drawer and on panel icons.
+
+There are two ways a badge is set:
+
+- **On load** — override `compute_notification_badge()` on your `Application`
+  handler to provide the initial count shown when Canvas loads applications. See
+  [Notification Badges](/sdk/handlers-applications/#notification-badges) on the
+  Applications handler page.
+- **Live updates** — emit an `ApplicationNotificationBadge` effect from any event
+  handler to update the count in real time, without the user reloading the page.
+  This is what the rest of this page covers.
+
+## Setting a badge
+
+`ApplicationNotificationBadge` is a fluent builder. Construct it with the target
+application's identifier, optionally `.filter(...)` to target patients, then call
+`.broadcast(...)` to produce the effect.
+
+| Method / Attribute       |          | Type        | Description                                                                                                                                                |
+| ------------------------ | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `application_identifier` | required | String      | Passed to the constructor. Must match the `class` string declared for the application in `CANVAS_MANIFEST.json`. An unknown identifier raises a validation error. |
+| `count`                  | required | Integer     | Passed to `.broadcast()`. The badge value to display. Must be `>= 0`; a count of `0` clears the badge.                                                      |
+| `staff_ids`              | optional | list[String] | Passed to `.broadcast()`. [Staff](/sdk/data-staff/) keys that should see the update.                                                                       |
+| `patient_ids`            | optional | list[String] | Passed to `.filter()`. [Patient](/sdk/data-patient/) keys whose chart context the update applies to.                                                       |
+
+```python
+from canvas_sdk.effects.application_notification_badge import ApplicationNotificationBadge
+
+# Set a badge of 3 for a specific staff member.
+ApplicationNotificationBadge("my_plugin__inbox").broadcast(count=3, staff_ids=["staff-key"])
+```
+
+## Targeting
+
+`staff_ids` and `patient_ids` control who sees the update:
+
+| `staff_ids` | `patient_ids` | Who sees the badge                                                                       |
+| ----------- | ------------- | ---------------------------------------------------------------------------------------- |
+| set         | empty         | The listed staff, wherever they view the application.                                    |
+| empty       | set           | Staff currently viewing the listed patients' charts.                                     |
+| set         | both          | The listed staff, but only while viewing the listed patients' charts.                    |
+| empty       | empty         | All staff (a system-wide update).                                                        |
+
+Patients are never subscribers themselves — `patient_ids` scopes the badge to a
+patient's chart, where staff viewing that chart will see it.
+
+```python
+# Show a badge to staff viewing a specific patient's chart.
+ApplicationNotificationBadge("my_plugin__patient_labs").filter(
+    patient_ids=["patient-key"]
+).broadcast(count=5)
+
+# Combine: only the on-call provider, and only on this patient's chart.
+ApplicationNotificationBadge("my_plugin__patient_labs").filter(
+    patient_ids=["patient-key"]
+).broadcast(count=1, staff_ids=["staff-key"])
+```
+
+## Reacting to events
+
+The most common pattern is updating a badge in response to a domain event. Here a
+handler recomputes a staff member's inbox count whenever a task is created and
+pushes the new value live:
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.application_notification_badge import ApplicationNotificationBadge
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers import BaseHandler
+from canvas_sdk.v1.data.task import Task, TaskStatus
+
+
+class InboxBadgeHandler(BaseHandler):
+    RESPONDS_TO = EventType.Name(EventType.TASK__CREATED)
+
+    def compute(self) -> list[Effect]:
+        task = Task.objects.get(id=self.event.target.id)
+        assignee = task.assignee
+        if not assignee:
+            return []
+
+        open_count = Task.objects.filter(assignee=assignee, status=TaskStatus.OPEN).count()
+
+        return [
+            ApplicationNotificationBadge("my_plugin__inbox").broadcast(
+                count=open_count,
+                staff_ids=[assignee.id],
+            )
+        ]
+```
+
+## Clearing a badge
+
+Broadcast a `count` of `0` to remove the badge from the icon:
+
+```python
+ApplicationNotificationBadge("my_plugin__inbox").broadcast(count=0, staff_ids=["staff-key"])
+```
+
+> **Note:** To set the badge value shown when applications first load (rather than
+> in response to an event), override `compute_notification_badge()` on your
+> `Application` handler. See
+> [Notification Badges](/sdk/handlers-applications/#notification-badges).

--- a/collections/_sdk/effects/application_notification_badge.md
+++ b/collections/_sdk/effects/application_notification_badge.md
@@ -42,17 +42,26 @@ ApplicationNotificationBadge("my_plugin__inbox").broadcast(count=3, staff_ids=["
 
 ## Targeting
 
-`staff_ids` and `patient_ids` control who sees the update:
+`staff_ids` and `patient_ids` control who sees the update. An empty list means
+"all" on that axis:
 
 | `staff_ids` | `patient_ids` | Who sees the badge                                                                       |
 | ----------- | ------------- | ---------------------------------------------------------------------------------------- |
-| set         | empty         | The listed staff, wherever they view the application.                                    |
+| set         | empty         | The listed staff, on any patient (and on global views).                                  |
 | empty       | set           | Staff currently viewing the listed patients' charts.                                     |
-| set         | both          | The listed staff, but only while viewing the listed patients' charts.                    |
-| empty       | empty         | All staff (a system-wide update).                                                        |
+| set         | set           | The listed staff, but only while viewing the listed patients' charts.                    |
+| empty       | empty         | All staff, all patients (a system-wide update).                                          |
 
 Patients are never subscribers themselves — `patient_ids` scopes the badge to a
 patient's chart, where staff viewing that chart will see it.
+
+> **Note on "all patients" (empty `patient_ids`):** the update is delivered
+> **live** only to charts a staff member currently has open. Other patients'
+> charts reflect the new value the next time they're loaded, via
+> `compute_notification_badge()`. So for a badge that should read the same across
+> every patient, have `compute_notification_badge()` return a patient-independent
+> count (ignore the patient in `self.event.context`). A push then keeps the
+> open chart live, and the load-time hook covers the rest.
 
 ```python
 # Show a badge to staff viewing a specific patient's chart.

--- a/collections/_sdk/events.md
+++ b/collections/_sdk/events.md
@@ -21930,6 +21930,29 @@ For more information on these events, see <a href="/sdk/handlers-applications" t
   </tbody>
 </table>
 
+<table>
+  <thead>
+    <tr><th colspan="2">APPLICATION__GET_NOTIFICATION_BADGE</th></tr>
+    <tr><td colspan="2">Occurs when Canvas loads applications and requests the current notification badge count. Respond by overriding <code>compute_notification_badge()</code> on your <a href="/sdk/handlers-applications/#notification-badges">Application</a> handler.</td></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Target</td>
+      <td>Context object</td>
+    </tr>
+    <tr>
+      <td><pre>application_id</pre></td>
+      <td><pre>
+  "staff":
+    "id": str
+    "type": <a href='/sdk/data-staff/'>Staff</a>
+  "patient":
+    "id": str
+    "type": <a href='/sdk/data-patient/'>Patient</a></pre></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Patient Chart Configuration
 
 <table>

--- a/collections/_sdk/handlers/applications.md
+++ b/collections/_sdk/handlers/applications.md
@@ -429,6 +429,71 @@ Here's what your `CANVAS_MANIFEST.json` might look like:
 }
 ```
 
+## Notification Badges
+
+You can display a notification badge — a small count — on your application's
+icon, both in the app drawer and on panel icons. A badge is useful for surfacing
+how many items are waiting for attention, such as unread messages or open tasks.
+
+### Initial count on load
+
+Override `compute_notification_badge()` on your `Application` handler to provide
+the count shown when Canvas loads applications. Return an integer to show a badge,
+or `None` (the default) to show no badge. A count of `0` shows no badge.
+
+```python
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.launch_modal import LaunchModalEffect
+from canvas_sdk.handlers.application import Application
+from canvas_sdk.v1.data.task import Task, TaskStatus
+
+
+class InboxApp(Application):
+    def on_open(self) -> Effect | list[Effect]:
+        return LaunchModalEffect(
+            url="https://www.your-app.com/inbox",
+            title="Inbox",
+        ).apply()
+
+    def compute_notification_badge(self) -> int | None:
+        """Return the badge count shown on the icon when applications load."""
+        staff_id = self.event.context.get("staff", {}).get("id")
+        if not staff_id:
+            return None
+        return Task.objects.filter(assignee__id=staff_id, status=TaskStatus.OPEN).count()
+```
+
+When the application is rendered on a patient chart (`patient_specific` scope),
+the event context also carries the patient, so you can compute a count specific
+to the staff member *and* the patient they are viewing:
+
+```python
+def compute_notification_badge(self) -> int | None:
+    staff_id = self.event.context.get("staff", {}).get("id")
+    patient_id = self.event.context.get("patient", {}).get("id")
+    if not (staff_id and patient_id):
+        return None
+    return unread_results_for(staff_id, patient_id)
+```
+
+The badge event context contains:
+
+| Key       | Description                                                          |
+| --------- | -------------------------------------------------------------------- |
+| `staff`   | A dict with the staff `id` and `type` (present for staff-facing apps). |
+| `patient` | A dict with the patient `id` and `type` (present on a patient chart). |
+
+> **Note:** Note Applications (`NoteApplication` / `EmbeddedApplication`) do not
+> support notification badges.
+
+### Live updates
+
+To change the count after load — for example, in response to a new task or
+message — emit an `ApplicationNotificationBadge` effect from any event handler.
+The badge updates in real time without the user reloading the page. See the
+[Application Notification Badge](/sdk/effect-application-notification-badge/)
+effect for details.
+
 
 <br/>
 <br/>


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-3801

This pull request introduces documentation for the new Application Notification Badge feature in the SDK. It explains how to display and update notification badge counts on application icons, both when applications load and in response to live events. The changes include new and updated documentation pages, menu entries, and an event table describing how to implement and use notification badges in plugins.

**New documentation for Application Notification Badges:**

- Added a new SDK documentation page, `application_notification_badge.md`, describing how to use the `ApplicationNotificationBadge` effect to display and update notification badge counts on application icons, including usage examples, targeting, and event-driven updates.
- Updated the `effects_module` menu in `_data/menus.yml` to include the new "Application Notification Badge" entry, linking to the documentation.

**Application handler and event documentation:**

- Added a section to the Applications handler documentation explaining how to override `compute_notification_badge()` to set the initial badge count when applications load, with code examples for both staff- and patient-specific contexts.
- Updated the SDK events documentation to include the `APPLICATION__GET_NOTIFICATION_BADGE` event, which occurs when Canvas loads applications and requests the current notification badge count, describing the event context and expected handler override.