### PR TITLE
Automate quarterly FHIR service base URL refresh

### DIFF
--- a/.github/workflows/refresh-fhir-service-base-urls.yml
+++ b/.github/workflows/refresh-fhir-service-base-urls.yml
@@ -23,9 +23,22 @@ jobs:
         with:
           python-version: "3.14"
 
+      # Console (console.canvasmedical.com) is only reachable over Tailscale.
+      # Step copied from canvas-claude-usage/.github/workflows/weekly-report.yml.
+      - name: Tailscale
+        env:
+          TAILSCALE_EXIT_NODE_IP: ${{ secrets.TAILSCALE_EXIT_NODE_IP }}
+        uses: tailscale/github-action@v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          args: --exit-node ${{ env.TAILSCALE_EXIT_NODE_IP }}
+          ping: ${{ env.TAILSCALE_EXIT_NODE_IP }}
+
       - name: Regenerate FHIR service base URL bundles
         env:
-          CONSOLE_BASE_URL: ${{ secrets.CONSOLE_BASE_URL }}
+          CONSOLE_BASE_URL: https://console.canvasmedical.com/api/v1/provisioning
           CONSOLE_AUTH_TOKEN: ${{ secrets.CONSOLE_AUTH_TOKEN }}
         run: uv run scripts/api/fhir_service_base_urls.py
 

--- a/.github/workflows/refresh-fhir-service-base-urls.yml
+++ b/.github/workflows/refresh-fhir-service-base-urls.yml
@@ -1,0 +1,45 @@
+name: Refresh FHIR Service Base URLs
+
+# Regenerates the published FHIR service base URL bundles from Console data and
+# opens a PR when they have changed. ONC 45 CFR 170.404(b)(2) requires these to be
+# "reviewed quarterly and, as necessary, updated" — the quarterly cron run is the
+# review and the resulting PR (or its absence) is the audit trail.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 09:00 UTC on the 1st of Jan, Apr, Jul, Oct
+    - cron: "0 9 1 1,4,7,10 *"
+
+jobs:
+  refresh-fhir-service-base-urls:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the docs repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.14"
+
+      - name: Regenerate FHIR service base URL bundles
+        env:
+          CONSOLE_BASE_URL: ${{ secrets.CONSOLE_BASE_URL }}
+          CONSOLE_AUTH_TOKEN: ${{ secrets.CONSOLE_AUTH_TOKEN }}
+        run: uv run scripts/api/fhir_service_base_urls.py
+
+      - name: Open pull request if the bundles changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PROJECT_AND_REPO_PAT }}
+          branch: refresh-fhir-service-base-urls-${{ github.run_id }}
+          add-paths: _static/fhir-service-base-urls-*.json
+          title: "Quarterly FHIR service base URL refresh"
+          commit-message: "chore: refresh FHIR service base URLs"
+          body: |
+            Automated quarterly regeneration of the published FHIR service base URL bundles from Console data, satisfying the "reviewed quarterly and, as necessary, updated" requirement in ONC 45 CFR 170.404(b)(2).
+
+            This PR was opened because the regenerated bundles differ from what is currently published — review the diff to confirm the additions/removals (new customers, churned customers, address changes) look correct, then merge to publish.
+
+            If no PR is opened on a scheduled run, the published bundles already match Console and no update was necessary.

--- a/scripts/api/fhir_service_base_urls.py
+++ b/scripts/api/fhir_service_base_urls.py
@@ -10,11 +10,15 @@ FHIR Bundle JSON files for non-production and production environments.
 Steps for updating the FHIR service base URLs in the documentation repository:
 
 1. Create a branch in the documentation repository.
-2. Set the CONSOLE_API_BASE_URL environment variable to the correct value
+2. Set the CONSOLE_BASE_URL environment variable to the correct value
    (see https://www.notion.so/canvasmedical/REST-API-3040bd9e403380a8ba1ac0b4a498ac5b).
-3. Set the CONSOLE_API_AUTH_TOKEN environment variable to your Canvas Console auth token.
-3. Run the script: uv run fhir_service_base_urls.py
-4. Create a PR from your branch and merge it.
+3. Set the CONSOLE_AUTH_TOKEN environment variable to your Canvas Console auth token.
+4. Run the script: uv run fhir_service_base_urls.py
+5. Create a PR from your branch and merge it.
+
+This process is also run quarterly (and on demand) by the
+.github/workflows/refresh-fhir-service-base-urls.yml GitHub Actions workflow, which
+opens a PR whenever the regenerated bundles differ from what is published.
 """
 
 # /// script


### PR DESCRIPTION
## What

Adds `.github/workflows/refresh-fhir-service-base-urls.yml`: a GitHub Actions workflow that regenerates the published FHIR service base URL bundles (`_static/fhir-service-base-urls-{production,nonproduction}.json`) from Console data and opens a PR whenever they differ from what is currently published.

Triggers: a quarterly `schedule` cron (09:00 UTC on the 1st of Jan/Apr/Jul/Oct) plus `workflow_dispatch` for on-demand runs. It reuses the existing `scripts/api/fhir_service_base_urls.py` and the same `peter-evans/create-pull-request` + `PROJECT_AND_REPO_PAT` pattern already used by the example-plugin-docs workflow.

Console (console.canvasmedical.com) is only reachable over Tailscale, so the workflow brings up Tailscale before the regeneration step, using the same step as canvas-claude-usage's `weekly-report.yml`. The non-sensitive `CONSOLE_BASE_URL` (`https://console.canvasmedical.com/api/v1/provisioning`) is hardcoded in the workflow, so the only Console secret needed is the auth token.

Also fixes the script docstring, which told you to set `CONSOLE_API_BASE_URL` / `CONSOLE_API_AUTH_TOKEN` while the code actually reads `CONSOLE_BASE_URL` / `CONSOLE_AUTH_TOKEN`.

## Why

ONC 45 CFR 170.404(b)(2) requires the published service base URL `Endpoint`/`Organization` bundles to be "reviewed quarterly and, as necessary, updated." Today this is a manual run that has to be remembered. The quarterly cron is the review; the resulting PR (or its absence when nothing changed) is the audit trail. The bundles were last updated 2026-02-10, so the review is currently overdue.

## Secrets required before this can run

- `CONSOLE_AUTH_TOKEN` — a Canvas Console auth token (prefer a long-lived service/bot token over a personal one so scheduled runs do not break on rotation)
- `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`, `TAILSCALE_EXIT_NODE_IP` — Tailscale OAuth client + exit node, same values canvas-claude-usage uses. If these already exist as canvas-medical org secrets, just add `documentation` to their repository visibility list instead of re-creating them.

`PROJECT_AND_REPO_PAT` already exists and is reused as-is. `CONSOLE_BASE_URL` is no longer needed as a secret (hardcoded).

Until the Console + Tailscale secrets are present, scheduled and manual runs will fail.