### PR TITLE
Clarify TASK_LABELS_ADJUSTED target is the label, not the task

### DIFF
--- a/collections/_sdk/events.md
+++ b/collections/_sdk/events.md
@@ -2935,7 +2935,7 @@ The following events fire when a prescription's status changes during the e-pres
 <table>
   <thead>
     <tr><th colspan="2">TASK_LABELS_ADJUSTED</th></tr>
-    <tr><td colspan="2">Occurs when a task's labels are changed.</td></tr>
+    <tr><td colspan="2">Occurs when a label is added to or removed from a task. <strong>Note:</strong> unlike the other <code>TASK_*</code> events, the target of this event is the <code>TaskLabel</code> that changed — <em>not</em> the task. The affected task's ID is available in the context object as <code>task.id</code> (use that to load the task, e.g. <code>Task.objects.get(id=self.event.context["task"]["id"])</code>), and <code>action</code> tells you whether the label was <code>add</code>ed or <code>remove</code>d.</td></tr>
   </thead>
   <tbody>
     <tr>


### PR DESCRIPTION
## What

Adds a clarifying note to the `TASK_LABELS_ADJUSTED` entry in the SDK events docs.

## Why

The event's **target object is the `TaskLabel`** that changed — unlike every other `TASK_*` event, whose target is the task itself. The values in the table were already correct (`target = task_label_id`, with `task.id` and `action` in the context), but the distinction wasn't called out, so it's easy to miss.

This bit a plugin author building a label-driven status tracker: they copied the `Task.objects.get(id=self.target)` pattern from a task webhook example, but for this event `self.target` is the **label** id, so that lookup raises `Task.DoesNotExist`. The affected task id lives in `event.context["task"]["id"]`.

## Change

The event description now spells out:
- the target is the `TaskLabel`, not the task
- how to load the task from context (`Task.objects.get(id=self.event.context["task"]["id"])`)
- that `action` reports whether the label was `add`ed or `remove`d

No table values changed — this is purely a clarifying note.

Generated from Support Stack investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)