### PR TITLE
Document ValueSet find() on Interview/ImagingReport/ReferralReport and ProtocolOverride helpers

### DIFF
--- a/collections/_sdk/data/imaging.md
+++ b/collections/_sdk/data/imaging.md
@@ -50,6 +50,19 @@ reviews = ImagingReview.objects.filter(is_released_to_patient=False)
 reports = ImagingReport.objects.filter(requires_signature=True)
 ```
 
+### By ValueSet
+
+`ImagingReport` supports `ValueSet` filtering through the `find` method on its model manager:
+
+```python
+from canvas_sdk.v1.data.imaging import ImagingReport
+from canvas_sdk.value_set.v2022.diagnostic_study import Mammography
+
+reports = ImagingReport.objects.find(Mammography)
+```
+
+`find` joins through the report's `codings` reverse relation and matches on `(system, code)` pairs from the value set, so a coding must match both the code system and the code to be included.
+
 ## Related Tasks
 To retrieve an Imaging Order's related tasks, use the `get_task_objects` method on the ImagingOrder object.
 

--- a/collections/_sdk/data/protocol_override.md
+++ b/collections/_sdk/data/protocol_override.md
@@ -51,6 +51,41 @@ from canvas_sdk.v1.data.protocol_override import ProtocolOverride
 overrides = ProtocolOverride.objects.filter(status="active")
 ```
 
+## Convenience methods
+
+The `ProtocolOverride` model manager includes convenience methods for the filters plugins most often apply when working with protocol overrides.
+
+`active` returns the overrides whose `status` is `active`:
+
+```python
+from canvas_sdk.v1.data.protocol_override import ProtocolOverride
+
+active_overrides = ProtocolOverride.objects.active()
+```
+
+`adjustments` returns the adjustment overrides (`is_adjustment=True`) for a given protocol key, and `snoozes` returns the snooze overrides (`is_snooze=True`) for a given protocol key:
+
+```python
+from canvas_sdk.v1.data.protocol_override import ProtocolOverride
+
+adjustments = ProtocolOverride.objects.adjustments("HCC001v1")
+snoozes = ProtocolOverride.objects.snoozes("HCC001v1")
+```
+
+Each method returns a queryset, so you can chain them with `for_patient`, `committed`, and with one another. For example, to get the active adjustments for a given patient and protocol key:
+
+```python
+from canvas_sdk.v1.data.protocol_override import ProtocolOverride
+
+adjustments = (
+    ProtocolOverride.objects
+    .for_patient("1eed3ea2a8d546a1b681a2a45de1d790")
+    .committed()
+    .active()
+    .adjustments("HCC001v1")
+)
+```
+
 ## Attributes
 
 ### ProtocolOverride

--- a/collections/_sdk/data/questionnaire.md
+++ b/collections/_sdk/data/questionnaire.md
@@ -98,6 +98,28 @@ from canvas_sdk.value_set.v2022.assessment import TobaccoUseScreening
 questionnaires = Questionnaire.objects.find(TobaccoUseScreening)
 ```
 
+`Interview` also supports `find`, which returns the interviews whose questionnaire has a code in the value set:
+
+```python
+from canvas_sdk.v1.data.questionnaire import Interview
+from canvas_sdk.value_set.v2022.assessment import TobaccoUseScreening
+
+interviews = Interview.objects.find(TobaccoUseScreening)
+```
+
+For interviews, `find` matches against the related `Questionnaire` through the `questionnaires` relation. Questionnaires store their code system by name (for example, `"LOINC"`) rather than by URL, and `find` handles this for you. It also composes with `for_patient`:
+
+```python
+from canvas_sdk.v1.data.questionnaire import Interview
+from canvas_sdk.value_set.v2022.assessment import TobaccoUseScreening
+
+interviews = (
+    Interview.objects
+    .for_patient("1eed3ea2a8d546a1b681a2a45de1d790")
+    .find(TobaccoUseScreening)
+)
+```
+
 ## Attributes
 
 ### ResponseOptionSet

--- a/collections/_sdk/data/referral.md
+++ b/collections/_sdk/data/referral.md
@@ -50,6 +50,19 @@ reports = ReferralReport.objects.filter(requires_signature=True)
 reviews = ReferralReview.objects.filter(status="completed")
 ```
 
+### By ValueSet
+
+`ReferralReport` supports `ValueSet` filtering through the `find` method on its model manager:
+
+```python
+from canvas_sdk.v1.data.referral import ReferralReport
+from canvas_sdk.value_set.v2022.procedure import DialysisServices
+
+reports = ReferralReport.objects.find(DialysisServices)
+```
+
+`find` joins through the report's `codings` reverse relation and matches on `(system, code)` pairs from the value set, so a coding must match both the code system and the code to be included.
+
 ## Related Tasks
 To retrieve an Referral's related tasks, use the `get_task_objects` method on the Referral object.
 
@@ -111,6 +124,7 @@ tasks = referral.get_task_objects().all()
 | priority           | Boolean                                                               |
 | original_date      | Date                                                                  |
 | review             | [ReferralReview](#referralreview)                                     |
+| codings            | [ReferralReportCoding](#referralreportcoding)[]                       |
 
 ### ReferralReview
 
@@ -130,3 +144,20 @@ tasks = referral.get_task_objects().all()
 | note                          | [Note](/sdk/data-note/#note)                |
 | patient                       | [Patient](/sdk/data-patient/#patient)  |
 | patient_communication_method  | String                                 |
+
+### ReferralReportCoding
+
+| Field Name    | Type                              |
+|---------------|-----------------------------------|
+| dbid          | Integer                           |
+| report        | [ReferralReport](#referralreport) |
+| system        | String                            |
+| version       | String                            |
+| code          | String                            |
+| display       | String                            |
+| user_selected | Boolean                           |
+| value         | String                            |
+
+<br/>
+<br/>
+<br/>


### PR DESCRIPTION
Adds find(value_set) examples for Interview, ImagingReport, and ReferralReport, the new ReferralReportCoding attributes, and the ProtocolOverride active()/adjustments()/snoozes() convenience methods (canvas-plugins #1773, canvas #19261, KOALA-5892).