### PR TITLE
Document the "Open on load" application setting

### DIFF
--- a/collections/_sdk/handlers/applications.md
+++ b/collections/_sdk/handlers/applications.md
@@ -438,6 +438,35 @@ Here's what your `CANVAS_MANIFEST.json` might look like:
 }
 ```
 
+## Opening an Application on Load
+
+You can configure an application to open **automatically**, without the user
+clicking its icon, by enabling the **Open on load** setting for that application
+in your instance settings.
+
+To enable it, go to the Plugins_IO > Applications section of your instance settings
+(`/admin/plugin_io/application/`), open the application you want, check
+**Open on load**, and save. If you don't have access to this setting, reach out
+to Canvas Support.
+
+Behavior depends on the application's [scope](#application-scopes):
+
+| Scope              | When it opens                                    |
+|--------------------|--------------------------------------------------|
+| `global`           | Automatically when the app shell first loads.    |
+| `patient_specific` | Automatically when a patient chart is opened.    |
+
+This is an instance-level setting configured per application in your instance
+settings. It is **not** part of `CANVAS_MANIFEST.json`, so the value you set is
+preserved when the plugin is reinstalled or updated.
+
+{% include alert.html type="warning" content="<b>Enable Open on load for at most one application per scope.</b> There is no priority or ordering logic for this setting, and no constraint preventing multiple applications in the same scope from being flagged. If more than one application in the same scope (for example, two <code>patient_specific</code> apps) has Open on load enabled, all of them will attempt to open, resulting in unpredictable behavior. Make sure only one application per scope is set to open on load." %}
+
+> **Note:** This is distinct from a Note Application's
+> [`open_by_default()`](#opening-by-default), which controls which **tab** is
+> active when a note is viewed. **Open on load** controls whether a `global` or
+> `patient_specific` application opens automatically on app/chart load.
+
 ## Notification Badges
 
 You can display a notification badge — a small count — on the icon of a `global`


### PR DESCRIPTION
## What

Adds an **"Opening an Application on Load"** section to the Applications handler doc (`collections/_sdk/handlers/applications.md`), documenting the per-application **Open on load** setting available in instance settings.

It covers:
- How to enable it (instance settings → Applications), and to contact Canvas Support if you don't have access.
- Behavior by scope — `global` apps open on app-shell load; `patient_specific` apps open on patient chart load.
- That it's an instance-level setting, not part of `CANVAS_MANIFEST.json`, so it's preserved across plugin reinstalls/updates.
- A **warning callout** (`alert.html type="warning"`): there is no priority logic and no unique constraint, so only one application per scope should be set to open on load — otherwise all of them attempt to open with unpredictable results.
- A note distinguishing it from a Note Application's `open_by_default()` (tab selection).

## Why

Closes a documentation gap surfaced while investigating canvas-plugins #580 / KOALA-3084: the auto-open capability exists for chart applications via this admin flag but was undocumented.

Drafted from a Support Stack investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)