### PR TITLE
Serve llms.txt, llms-full.txt, and per-page markdown for LLMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# Canvas Medical Documentation
+
+Developer documentation site for Canvas Medical's SDK, FHIR API, implementation guides, and release notes.
+
+**Production:** https://docs.canvasmedical.com
+
+## Tech Stack
+
+- **Site generator:** Jekyll 4.4 (Ruby 3.1)
+- **Assets:** Webpack 5, SCSS, Babel
+- **Python tooling:** uv, Python 3.11+ (code block validation, context generation)
+- **Package managers:** Yarn 3.x (frontend), Bundler 2.x (Ruby), uv (Python)
+- **Search:** Algolia
+- **Hosting:** AWS Amplify
+
+## Quick Start
+
+```sh
+# With Devbox (recommended)
+devbox run dev
+
+# Manual
+yarn install && bundle install
+yarn dev
+```
+
+Dev server runs on ports 4000 (Jekyll) and 4001 (Webpack).
+
+## Project Structure
+
+```
+collections/           # All content (Jekyll collections)
+  _api/                # FHIR API resource docs (~60 files)
+  _sdk/                # SDK docs (~140 files)
+    data/              # Data models (Patient, DocumentReference, etc.)
+    handlers/          # Handler types (CronTask, SimpleAPI, etc.)
+    effects/           # SDK effects/operations
+    commands/          # SDK commands
+    clients/           # Third-party integrations
+    examples/          # Reference implementations
+  _guides/             # Implementation guides (~22 files)
+  _release-notes/      # Product updates (~525 files, by year/quarter)
+  _documentation/      # Misc docs
+  _learn/              # Educational content
+  _fdb-changelogs/     # FDB integration changelogs
+_layouts/              # Jekyll layout templates
+_includes/             # Reusable HTML partials
+_data/
+  menus.yml            # Navigation/sidebar structure
+  globals.yml          # UI labels
+  api-attributes.yml   # API doc metadata
+_scss/                 # Style partials
+_js/                   # JavaScript source
+config/                # Webpack configs
+```
+
+## Content Conventions
+
+### SDK data docs (`collections/_sdk/data/*.md`)
+
+Frontmatter:
+```yaml
+---
+title: "ModelName"
+slug: "data-model-name"
+excerpt: "Short description"
+hidden: false
+---
+```
+
+Content pattern: heading, intro paragraph, Basic Usage section with code, Filtering section, Attributes table. Code examples use Django-style ORM queries (`Model.objects.filter(...)`).
+
+### API docs (`collections/_api/*.md`)
+
+Frontmatter uses a structured `sections` → `blocks` → `apidoc` format with `attributes`, `search_parameters`, `endpoints`, and example references. These are complex — read an existing file before editing.
+
+### Navigation
+
+Sidebar menus are defined in `_data/menus.yml`. Add entries there when creating new pages.
+
+### Markdown features
+
+- Code blocks: standard fenced blocks with language tag (` ```python `)
+- Partial code blocks: ` ```python?partial=true ` — only imports are validated
+- Alerts: `{% include alert.html type="warning" content="..." %}`
+  - Types: `warning`, `info`, `danger`, `github`
+- Tabs (API docs): `{% tabs block-id %}` / `{% tab block-id lang %}` / `{% endtab %}` / `{% endtabs %}`
+- Internal links: `[text](/sdk/data-model-name/)`, `[text](/api/resource/)`
+
+## Domain Knowledge
+
+### Identifiers
+
+- **Patient keys** and **staff keys** are UUIDs **without dashes** (e.g., `b80b1cdc2e6a4aca90ccebc02e683f35`). This is unlike most other Canvas identifiers which use standard UUID format with dashes.
+- Other IDs (document references, encounters, etc.) use standard UUID format with dashes (e.g., `d2194110-5c9a-4842-8733-ef09ea5ead11`).
+
+### SDK data model patterns
+
+Models follow Django ORM conventions:
+- `Model.objects.get(id="...")` — single object by ID
+- `Model.objects.filter(field=value)` — queryset filtering
+- `Model.objects.for_patient("patient_key")` — patient-scoped queries (key without dashes)
+- Related models are linked via foreign keys with `/sdk/data-*` URLs
+
+## Testing
+
+Python code blocks in markdown are validated by `test-code-blocks.py`:
+- Extracts fenced Python blocks from all `collections/**/*.md` files
+- Validates imports and variable references via AST parsing
+- Runs on every PR via GitHub Actions (Python 3.11, 3.12, 3.13)
+- Unfenced or unlabeled code blocks are flagged as errors
+- Mark blocks as `python?partial=true` if they intentionally omit imports
+
+Run locally:
+```sh
+uv run ./test-code-blocks.py
+```
+
+## CI/CD
+
+- **test-code-blocks.yml** — validates Python code examples on PRs
+- **generate-context.yml** — builds AI context files (`sdk-context.txt`, `fhir-context.txt`) on push to main
+- **update-algolia.yml** — updates search index
+- **merge-release-branch.yml** — auto-merges release branches
+
+## AI / LLM access
+
+The site serves machine-readable copies of its docs for LLMs and coding agents (llmstxt.org convention):
+- `/llms.txt` — curated index linking to the `.md` version of each core reference page; release notes and FDB changelogs sit under the droppable `## Optional` section.
+- `/llms-full.txt` — the full SDK + FHIR API + guides corpus concatenated as one markdown file.
+- `/<page>.md` — a clean-markdown mirror of every content page (append `.md` to any URL, e.g. `/sdk/data-patient.md`).
+
+`generate-llms.py` produces all three into `_site/` after `jekyll build` (wired into `yarn build`, so Amplify emits them on every deploy; they are not committed). The HTML→markdown extraction is shared with `generate-context.py` via `context_extractor.py`.
+
+The older `sdk-context.txt` / `fhir-context.txt` (used by the Canvas Plugin Assistant) are still generated and committed by `generate-context.py`.
+
+## Build
+
+```sh
+yarn build          # Production build → _site/ (also emits llms.txt, llms-full.txt, .md mirrors)
+yarn build:llms     # Regenerate llms.txt/llms-full.txt/.md mirrors from an existing _site/
+yarn build:pwa      # With service worker + manifest
+yarn serve:dist     # Serve built output locally
+yarn clean:project  # Remove _site and generated assets
+```
+
+Algolia index update:
+```sh
+ALGOLIA_API_KEY='key' bundle exec jekyll algolia --config _config.yml,_config_apikeys.yml
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Dev server runs on ports 4000 (Jekyll) and 4001 (Webpack).
 
 ## Project Structure
 
-```
+```text
 collections/           # All content (Jekyll collections)
   _api/                # FHIR API resource docs (~60 files)
   _sdk/                # SDK docs (~140 files)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To build the website run the following line
 ```sh
 yarn build
 ```
-The built website will be in `_site` folder.
+The built website will be in `_site` folder. The build also emits LLM-facing artifacts into `_site`: `llms.txt` (index), `llms-full.txt` (full corpus), and a `.md` mirror of every page (via `generate-llms.py`). These require `uv` on the PATH. To regenerate them against an existing `_site` without a full rebuild, run `yarn build:llms`.
 
 You can also run a local server to test it with this command
 ```sh

--- a/_config.yml
+++ b/_config.yml
@@ -105,8 +105,15 @@ exclude:
   - _src
   - amplify.yml
   - config
+  - context_extractor.py
+  - generate-context.py
+  - generate-llms.py
   - icon.png
+  - mypy.ini
   - node_modules
+  - pyproject.toml
+  - test-code-blocks.py
+  - uv.lock
   - optimization-fix
   - optimization-fix-this-file-is-ignored.js
   - package.json

--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,7 @@ exclude:
   - amplify.yml
   - config
   - context_extractor.py
+  - customHttp.yml
   - generate-context.py
   - generate-llms.py
   - icon.png

--- a/amplify.yml
+++ b/amplify.yml
@@ -19,20 +19,3 @@ frontend:
       - '**/*'
   cache:
     paths: []
-customHeaders:
-  # LLM-facing markdown mirrors: render as text, keep out of search results
-  # so they don't compete with the canonical HTML pages.
-  - pattern: '**/*.md'
-    headers:
-      - key: Content-Type
-        value: 'text/markdown; charset=utf-8'
-      - key: X-Robots-Tag
-        value: 'noindex'
-  - pattern: '/llms.txt'
-    headers:
-      - key: X-Robots-Tag
-        value: 'noindex'
-  - pattern: '/llms-full.txt'
-    headers:
-      - key: X-Robots-Tag
-        value: 'noindex'

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,8 +6,10 @@ frontend:
         - rvm install $(cat .ruby-version)
         - rvm use $(cat .ruby-version)
         - gem install bundler -v 2.4.12
+        - curl -LsSf https://astral.sh/uv/install.sh | sh
     build:
       commands:
+        - export PATH="$HOME/.local/bin:$PATH"
         - bundle install
         - yarn install
         - yarn build
@@ -17,3 +19,20 @@ frontend:
       - '**/*'
   cache:
     paths: []
+customHeaders:
+  # LLM-facing markdown mirrors: render as text, keep out of search results
+  # so they don't compete with the canonical HTML pages.
+  - pattern: '**/*.md'
+    headers:
+      - key: Content-Type
+        value: 'text/markdown; charset=utf-8'
+      - key: X-Robots-Tag
+        value: 'noindex'
+  - pattern: '/llms.txt'
+    headers:
+      - key: X-Robots-Tag
+        value: 'noindex'
+  - pattern: '/llms-full.txt'
+    headers:
+      - key: X-Robots-Tag
+        value: 'noindex'

--- a/context_extractor.py
+++ b/context_extractor.py
@@ -1,0 +1,186 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyyaml",
+#     "beautifulsoup4",
+#     "html2text",
+# ]
+# ///
+
+"""Shared helpers for turning the built Jekyll site into markdown.
+
+Both generate-context.py (SDK/FHIR coding-agent context files) and
+generate-llms.py (llms.txt, llms-full.txt, per-page .md) import from here so the
+HTML->markdown extraction lives in exactly one place.
+"""
+
+import re
+from pathlib import Path
+
+import html2text
+import yaml
+from bs4 import BeautifulSoup, Tag
+
+REPO_ROOT = Path(__file__).resolve().parent
+BASE_URL = "https://docs.canvasmedical.com"
+SITE_DIR = REPO_ROOT / "_site"
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.+?)\n---\n?", re.DOTALL)
+
+# Alert type → label for markdown conversion
+ALERT_LABELS = {
+    "alert__info": "Info",
+    "alert__warning": "Warning",
+    "alert__danger": "Danger",
+}
+
+
+def frontmatter(path: Path) -> dict:
+    """Parse the YAML frontmatter of a collection markdown file."""
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    try:
+        return yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def url_path_for(path: Path, collection: str) -> str:
+    """Compute the URL path for a collection markdown file."""
+    slug = frontmatter(path).get("slug")
+
+    if slug is not None:
+        slug = str(slug).strip()
+        return f"/{collection}/" if slug == "/" else f"/{collection}/{slug}/"
+
+    return f"/{collection}/{path.stem}/"
+
+
+def html_path_for(url_path: str) -> Path:
+    """Map a URL path to the built HTML file in _site/."""
+    # /sdk/ -> _site/sdk/index.html
+    # /sdk/commands/ -> _site/sdk/commands/index.html
+    return SITE_DIR / url_path.strip("/") / "index.html"
+
+
+def preprocess_code_blocks(soup: BeautifulSoup, container: Tag) -> None:
+    """Convert Rouge-highlighted code blocks to markdown fenced blocks."""
+    for div in container.find_all("div", class_="highlighter-rouge"):
+        classes = div.get("class", [])
+        lang = ""
+        for cls in classes:
+            if cls.startswith("language-"):
+                lang = cls.removeprefix("language-")
+                break
+
+        code_tag = div.find("code")
+        if not code_tag:
+            continue
+
+        code_text = code_tag.get_text()
+        # Strip single trailing newline that Rouge adds
+        if code_text.endswith("\n"):
+            code_text = code_text[:-1]
+
+        replacement = soup.new_tag("pre")
+        replacement.string = f"```{lang}\n{code_text}\n```"
+        div.replace_with(replacement)
+
+
+def preprocess_alerts(soup: BeautifulSoup, container: Tag) -> None:
+    """Convert alert aside elements to blockquote-style markdown."""
+    for aside in container.find_all("aside", class_="alert"):
+        classes = aside.get("class", [])
+        label = "Note"
+        for cls in classes:
+            if cls in ALERT_LABELS:
+                label = ALERT_LABELS[cls]
+                break
+
+        content_div = aside.find("div", class_="alert__content")
+        if not content_div:
+            continue
+
+        # Get inner HTML so html2text can process links etc.
+        inner_html = content_div.decode_contents()
+        replacement = soup.new_tag("blockquote")
+        replacement.append(
+            BeautifulSoup(f"<p><strong>{label}:</strong> {inner_html}</p>", "html.parser")
+        )
+        aside.replace_with(replacement)
+
+
+def preprocess_tabs(soup: BeautifulSoup, container: Tag) -> None:
+    """Add tab labels before each tab content panel."""
+    for tab_menu in container.find_all("ul", class_="tab"):
+        tab_id = tab_menu.get("data-tab")
+        if not tab_id:
+            continue
+
+        # Collect tab names
+        tab_names = []
+        for li in tab_menu.find_all("li", recursive=False):
+            a = li.find("a")
+            if a:
+                tab_names.append(a.get_text(strip=True))
+
+        # Find corresponding tab-content
+        content_ul = container.find("ul", class_="tab-content", id=tab_id)
+        if not content_ul:
+            continue
+
+        # Add a heading before each tab panel's content
+        content_items = content_ul.find_all("li", recursive=False)
+        for i, li in enumerate(content_items):
+            name = tab_names[i] if i < len(tab_names) else f"Tab {i + 1}"
+            label = soup.new_tag("p")
+            label.string = f"**{name}**"
+            li.insert(0, label)
+
+        # Remove the tab menu (the labels are now inline)
+        tab_menu.decompose()
+
+
+def extract_content(html_path: Path) -> str | None:
+    """Extract and convert the article content from a built HTML page."""
+    html = html_path.read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+
+    container = soup.find("div", class_="article__container__inner")
+    if not container:
+        return None
+
+    # Remove unwanted elements
+    for tag_name in ("header", "script", "style", "svg", "nav", "footer"):
+        for el in container.find_all(tag_name):
+            el.decompose()
+
+    # Remove anchor links (the # links after headings)
+    for a in container.find_all("a", class_="article__anchor"):
+        a.decompose()
+
+    # Pre-process special elements before html2text
+    preprocess_code_blocks(soup, container)
+    preprocess_alerts(soup, container)
+    preprocess_tabs(soup, container)
+
+    # Convert HTML to markdown
+    h = html2text.HTML2Text()
+    h.body_width = 0
+    h.unicode_snob = False
+    h.protect_links = False
+    h.wrap_links = False
+    h.mark_code = False
+    h.ul_item_mark = "-"
+
+    md = h.handle(str(container))
+
+    # Replace smart quotes with plain ASCII equivalents
+    md = md.translate(str.maketrans("‘’“”", "''\"\""))
+
+    # Strip blank lines to produce dense markdown
+    dense = "\n".join(line for line in md.splitlines() if line.strip())
+
+    return dense

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,23 @@
+# AWS Amplify custom response headers.
+#
+# Amplify reads custom headers from this file (repo root), NOT from a
+# customHeaders block in amplify.yml — that location is deprecated and silently
+# ignored. See docs.aws.amazon.com/amplify/latest/userguide/custom-headers.html.
+#
+# Keep the LLM-facing markdown mirrors and llms.txt/llms-full.txt out of search
+# results so they don't compete with the canonical HTML pages. (Content-Type is
+# set by Amplify's own MIME mapping — .md already serves as text/markdown — and
+# cannot be overridden here, so only X-Robots-Tag is set.)
+customHeaders:
+  - pattern: '**/*.md'
+    headers:
+      - key: 'X-Robots-Tag'
+        value: 'noindex'
+  - pattern: '/llms.txt'
+    headers:
+      - key: 'X-Robots-Tag'
+        value: 'noindex'
+  - pattern: '/llms-full.txt'
+    headers:
+      - key: 'X-Robots-Tag'
+        value: 'noindex'

--- a/generate-context.py
+++ b/generate-context.py
@@ -19,18 +19,18 @@ Requires: bundle exec jekyll build (run separately or via the JEKYLL_BUILD env v
 The _site/ directory must exist before running this script.
 """
 
-import re
 import subprocess
 import sys
 from pathlib import Path
 
-import html2text
-import yaml
-from bs4 import BeautifulSoup, Tag
-
-REPO_ROOT = Path(__file__).resolve().parent
-BASE_URL = "https://docs.canvasmedical.com"
-SITE_DIR = REPO_ROOT / "_site"
+from context_extractor import (
+    BASE_URL,
+    REPO_ROOT,
+    SITE_DIR,
+    extract_content,
+    html_path_for,
+    url_path_for,
+)
 
 # Guides are classified by stem (filename without .md) into SDK or FHIR.
 # Any guide not listed here is excluded (e.g., index.md landing page).
@@ -61,16 +61,6 @@ SDK_GUIDE_STEMS = {
 }
 
 
-FRONTMATTER_RE = re.compile(r"\A---\n(.+?)\n---\n?", re.DOTALL)
-
-# Alert type → label for markdown conversion
-ALERT_LABELS = {
-    "alert__info": "Info",
-    "alert__warning": "Warning",
-    "alert__danger": "Danger",
-}
-
-
 def build_jekyll() -> None:
     """Run Jekyll build if _site/ doesn't exist."""
     if SITE_DIR.exists():
@@ -86,154 +76,6 @@ def build_jekyll() -> None:
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
         sys.exit(f"Jekyll build failed (exit {result.returncode})")
-
-
-def url_path_for(path: Path, collection: str) -> str:
-    """Compute the URL path for a collection markdown file."""
-    text = path.read_text(encoding="utf-8")
-    match = FRONTMATTER_RE.match(text)
-
-    if match:
-        try:
-            meta = yaml.safe_load(match.group(1)) or {}
-        except yaml.YAMLError:
-            meta = {}
-    else:
-        meta = {}
-
-    slug = meta.get("slug")
-
-    if slug is not None:
-        slug = str(slug).strip()
-        return f"/{collection}/" if slug == "/" else f"/{collection}/{slug}/"
-
-    return f"/{collection}/{path.stem}/"
-
-
-def html_path_for(url_path: str) -> Path:
-    """Map a URL path to the built HTML file in _site/."""
-    # /sdk/ -> _site/sdk/index.html
-    # /sdk/commands/ -> _site/sdk/commands/index.html
-    return SITE_DIR / url_path.strip("/") / "index.html"
-
-
-def preprocess_code_blocks(soup: BeautifulSoup, container: Tag) -> None:
-    """Convert Rouge-highlighted code blocks to markdown fenced blocks."""
-    for div in container.find_all("div", class_="highlighter-rouge"):
-        classes = div.get("class", [])
-        lang = ""
-        for cls in classes:
-            if cls.startswith("language-"):
-                lang = cls.removeprefix("language-")
-                break
-
-        code_tag = div.find("code")
-        if not code_tag:
-            continue
-
-        code_text = code_tag.get_text()
-        # Strip single trailing newline that Rouge adds
-        if code_text.endswith("\n"):
-            code_text = code_text[:-1]
-
-        replacement = soup.new_tag("pre")
-        replacement.string = f"```{lang}\n{code_text}\n```"
-        div.replace_with(replacement)
-
-
-def preprocess_alerts(soup: BeautifulSoup, container: Tag) -> None:
-    """Convert alert aside elements to blockquote-style markdown."""
-    for aside in container.find_all("aside", class_="alert"):
-        classes = aside.get("class", [])
-        label = "Note"
-        for cls in classes:
-            if cls in ALERT_LABELS:
-                label = ALERT_LABELS[cls]
-                break
-
-        content_div = aside.find("div", class_="alert__content")
-        if not content_div:
-            continue
-
-        # Get inner HTML so html2text can process links etc.
-        inner_html = content_div.decode_contents()
-        replacement = soup.new_tag("blockquote")
-        replacement.append(BeautifulSoup(f"<p><strong>{label}:</strong> {inner_html}</p>", "html.parser"))
-        aside.replace_with(replacement)
-
-
-def preprocess_tabs(soup: BeautifulSoup, container: Tag) -> None:
-    """Add tab labels before each tab content panel."""
-    for tab_menu in container.find_all("ul", class_="tab"):
-        tab_id = tab_menu.get("data-tab")
-        if not tab_id:
-            continue
-
-        # Collect tab names
-        tab_names = []
-        for li in tab_menu.find_all("li", recursive=False):
-            a = li.find("a")
-            if a:
-                tab_names.append(a.get_text(strip=True))
-
-        # Find corresponding tab-content
-        content_ul = container.find("ul", class_="tab-content", id=tab_id)
-        if not content_ul:
-            continue
-
-        # Add a heading before each tab panel's content
-        content_items = content_ul.find_all("li", recursive=False)
-        for i, li in enumerate(content_items):
-            name = tab_names[i] if i < len(tab_names) else f"Tab {i + 1}"
-            label = soup.new_tag("p")
-            label.string = f"**{name}**"
-            li.insert(0, label)
-
-        # Remove the tab menu (the labels are now inline)
-        tab_menu.decompose()
-
-
-def extract_content(html_path: Path) -> str | None:
-    """Extract and convert the article content from a built HTML page."""
-    html = html_path.read_text(encoding="utf-8")
-    soup = BeautifulSoup(html, "html.parser")
-
-    container = soup.find("div", class_="article__container__inner")
-    if not container:
-        return None
-
-    # Remove unwanted elements
-    for tag_name in ("header", "script", "style", "svg", "nav", "footer"):
-        for el in container.find_all(tag_name):
-            el.decompose()
-
-    # Remove anchor links (the # links after headings)
-    for a in container.find_all("a", class_="article__anchor"):
-        a.decompose()
-
-    # Pre-process special elements before html2text
-    preprocess_code_blocks(soup, container)
-    preprocess_alerts(soup, container)
-    preprocess_tabs(soup, container)
-
-    # Convert HTML to markdown
-    h = html2text.HTML2Text()
-    h.body_width = 0
-    h.unicode_snob = False
-    h.protect_links = False
-    h.wrap_links = False
-    h.mark_code = False
-    h.ul_item_mark = "-"
-
-    md = h.handle(str(container))
-
-    # Replace smart quotes with plain ASCII equivalents
-    md = md.translate(str.maketrans("\u2018\u2019\u201c\u201d", "''\"\""))
-
-    # Strip blank lines to produce dense markdown
-    dense = "\n".join(line for line in md.splitlines() if line.strip())
-
-    return dense
 
 
 def collect_pages(collection: str) -> list[tuple[str, str]]:

--- a/generate-llms.py
+++ b/generate-llms.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env uv run
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyyaml",
+#     "beautifulsoup4",
+#     "html2text",
+# ]
+# ///
+
+"""Generate llms.txt, llms-full.txt, and per-page .md mirrors into _site/.
+
+Run AFTER `jekyll build` (the _site/ directory must already exist). Reuses the
+shared HTML->markdown extractor in context_extractor.py so the .md mirrors and
+llms-full.txt match sdk-context.txt / fhir-context.txt exactly.
+
+Outputs (all written into _site/, served statically by Amplify):
+  - _site/<path>.md         a clean-markdown mirror of every built content page
+  - _site/llms.txt          spec-compliant index (llmstxt.org), links to .md pages
+  - _site/llms-full.txt     the core reference corpus concatenated as markdown
+
+The .md mirrors are produced by walking the built HTML, so every page is covered
+regardless of how its permalink is derived. The curated llms.txt index and
+llms-full.txt corpus are driven by the collection front matter (titles, excerpts,
+ordering), with release notes and FDB changelogs kept behind the droppable
+`## Optional` section per the llmstxt.org convention.
+"""
+
+import sys
+from dataclasses import dataclass
+
+from context_extractor import (
+    BASE_URL,
+    REPO_ROOT,
+    SITE_DIR,
+    extract_content,
+    frontmatter,
+    url_path_for,
+)
+
+COLLECTIONS_DIR = REPO_ROOT / "collections"
+
+# Core reference sections: rendered as required H2 lists in llms.txt and
+# concatenated into llms-full.txt. (collection folder, url segment, heading).
+CORE_SECTIONS = [
+    ("_sdk", "sdk", "SDK"),
+    ("_api", "api", "FHIR API"),
+    ("_guides", "guides", "Guides"),
+    ("_learn", "learn", "Learn"),
+    ("_documentation", "documentation", "Other documentation"),
+]
+
+# Landing pages for the droppable `## Optional` section. Enumerating every
+# release note / changelog would bloat the index; link the indexes instead.
+OPTIONAL_LINKS = [
+    (
+        "Product release notes",
+        "/product-updates/release-notes/",
+        "Chronological feature, fix, and breaking-change log.",
+    ),
+    (
+        "FDB changelogs",
+        "/product-updates/fdb-changelogs/",
+        "Weekly First Databank drug-database updates.",
+    ),
+]
+
+SUMMARY = (
+    "Canvas Medical's developer documentation: the server-side Python SDK, the FHIR "
+    "API, and implementation guides for building EMR customizations. Patient and "
+    "staff keys are UUIDs without dashes; other identifiers use standard dashed UUIDs."
+)
+
+INDEX_INTRO = (
+    "This site documents how to extend and integrate with Canvas Medical, an EHR "
+    "platform: the server-side Python SDK (plugins, data models, handlers, effects, "
+    "commands), the FHIR API, and implementation guides. Every page is also available "
+    "as clean markdown by appending `.md` to its URL. The full reference corpus is "
+    f"concatenated at {BASE_URL}/llms-full.txt."
+)
+
+
+@dataclass
+class PageMeta:
+    url_path: str  # /sdk/data-patient/
+    title: str
+    excerpt: str
+
+    @property
+    def md_url(self) -> str:
+        return f"{BASE_URL}/{self.url_path.strip('/')}.md"
+
+
+def mirror_built_pages() -> dict[str, str]:
+    """Write a .md mirror next to every built content page.
+
+    Returns a {url_path: markdown} map so the index/corpus can reuse the
+    extracted content without re-parsing the HTML.
+    """
+    contents: dict[str, str] = {}
+
+    for html_path in sorted(SITE_DIR.rglob("index.html")):
+        rel = html_path.parent.relative_to(SITE_DIR).as_posix()
+        if rel == ".":
+            continue  # site-root landing page has no article content
+
+        content = extract_content(html_path)
+        if not content:
+            continue
+
+        url_path = f"/{rel}/"
+        contents[url_path] = content
+
+        out = SITE_DIR / f"{rel}.md"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(f"> Canonical page: {BASE_URL}{url_path}\n\n{content}\n", encoding="utf-8")
+
+    print(f"Wrote {len(contents)} .md mirrors")
+    return contents
+
+
+def collect_meta(collection_folder: str, url_segment: str) -> list[PageMeta]:
+    """Read title/excerpt/url for every visible page in a collection."""
+    coll_dir = COLLECTIONS_DIR / collection_folder
+    pages: list[PageMeta] = []
+
+    for md_path in sorted(coll_dir.rglob("*.md")):
+        meta = frontmatter(md_path)
+        if meta.get("hidden") is True:
+            continue
+        pages.append(
+            PageMeta(
+                url_path=url_path_for(md_path, url_segment),
+                title=str(meta.get("title") or md_path.stem).strip(),
+                excerpt=str(meta.get("excerpt") or "").strip(),
+            )
+        )
+
+    pages.sort(key=lambda p: p.url_path)
+    return pages
+
+
+def main() -> None:
+    if not SITE_DIR.exists():
+        sys.exit("_site/ not found. Run `bundle exec jekyll build` first.")
+
+    contents = mirror_built_pages()
+
+    # Core sections: only pages that actually rendered article content.
+    core = []
+    for folder, segment, heading in CORE_SECTIONS:
+        pages = [p for p in collect_meta(folder, segment) if p.url_path in contents]
+        if pages:
+            core.append((heading, pages))
+
+    # llms.txt — the spec-compliant index (links point at the .md mirrors).
+    lines = ["# Canvas Medical Developer Documentation", "", f"> {SUMMARY}", "", INDEX_INTRO, ""]
+    for heading, pages in core:
+        lines.append(f"## {heading}")
+        for p in pages:
+            bullet = f"- [{p.title}]({p.md_url})"
+            if p.excerpt:
+                bullet += f": {p.excerpt}"
+            lines.append(bullet)
+        lines.append("")
+
+    lines.append("## Optional")
+    for title, path, desc in OPTIONAL_LINKS:
+        lines.append(f"- [{title}]({BASE_URL}{path}): {desc}")
+    lines.append("")
+
+    (SITE_DIR / "llms.txt").write_text("\n".join(lines), encoding="utf-8")
+    core_count = sum(len(pages) for _heading, pages in core)
+    print(f"Wrote llms.txt ({core_count} core links)")
+
+    # llms-full.txt — the core reference corpus concatenated as markdown.
+    full = ["# Canvas Medical Developer Documentation (Full Reference)", "", f"> {SUMMARY}", ""]
+    for _heading, pages in core:
+        for p in pages:
+            full += [
+                f"# {p.title}",
+                "",
+                f"Source: {BASE_URL}{p.url_path}",
+                "",
+                contents[p.url_path],
+                "",
+                "---",
+                "",
+            ]
+
+    (SITE_DIR / "llms-full.txt").write_text("\n".join(full), encoding="utf-8")
+    print(f"Wrote llms-full.txt ({core_count} pages)")
+
+
+if __name__ == "__main__":
+    main()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "yarn clean:project && webpack --env config=dev --progress --profile --color && concurrently \"webpack-dev-server --env config=dev\" \"bundle exec jekyll serve --port 4001 --config _config.yml,_config_apikeys.yml\"",
-    "build": "yarn clean:project && cross-env NODE_ENV=production webpack --env config=prod --progress --profile --color && cross-env JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config_apikeys.yml,_config_production.yml",
+    "build": "yarn clean:project && cross-env NODE_ENV=production webpack --env config=prod --progress --profile --color && cross-env JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config_apikeys.yml,_config_production.yml && yarn build:llms",
+    "build:llms": "uv run ./generate-llms.py",
     "build:pwa": "yarn clean:project && cross-env NODE_ENV=production webpack --env config=pwa --progress --profile --color && cross-env JEKYLL_ENV=pwa bundle exec jekyll build --config _config.yml,_config_apikeys.yml,_config_production.yml && workbox generateSW config/sw.config.js --verbose",
     "serve:dist": "http-server _site",
     "clean:project": "rimraf ./_site ./assets"

--- a/test-code-blocks.py
+++ b/test-code-blocks.py
@@ -256,6 +256,11 @@ def check(fail_fast: bool = False, quiet: bool = False) -> None:
         if "node_modules" in markdown_file:
             continue
 
+        # Skip build output (_site/): generate-llms.py writes a .md mirror of
+        # every page there, and those are validated via their collection source.
+        if markdown_file.startswith("_site/") or "/_site/" in markdown_file:
+            continue
+
         # Choosing to skip generated example plugin documentation.
         # These docs include whole files directly from the plugin, which may
         # reference other files within that plugin package. Those imports will


### PR DESCRIPTION
## What

Adds machine-readable copies of the docs following the [llmstxt.org](https://llmstxt.org/) convention so coding agents and LLMs (Cursor, Claude Code, Copilot, Cline, etc.) can consume docs.canvasmedical.com directly. This is the developer/agent audience the site already targets with the `-context.txt` files, extended to the standard the ecosystem tooling actually reads.

Three new artifacts, all served from the site root:

- **`/llms.txt`** — a curated index (~21 KB): an `H1` + summary blockquote, then one `H2` list per core reference section (SDK, FHIR API, Guides, Learn) linking to the `.md` version of each page. Release notes and FDB changelogs sit under the spec's droppable `## Optional` section (linked via their index pages rather than enumerating ~570 entries).
- **`/llms-full.txt`** — the full SDK + FHIR API + guides corpus concatenated as one markdown file (~3 MB), for tools with large context windows or RAG ingestion.
- **`/<page>.md`** — a clean-markdown mirror of every content page. Append `.md` to any URL (e.g. `/sdk/data-patient.md`, `/api/patient.md`, `/release-notes/1-186-0.md`). ~725 pages.

## How

`generate-llms.py` runs after `jekyll build` and writes all three into `_site/`. It is wired into `yarn build`, so AWS Amplify emits them fresh on every deploy — none are committed to git (there are hundreds of `.md` files and they'd churn constantly).

The `.md` mirrors are produced by walking the **built** HTML (`_site/**/index.html`), so every page is covered regardless of how its permalink is derived — no fragile source-filename-to-URL guessing. The curated `llms.txt` index and `llms-full.txt` corpus are driven by the collection front matter (titles, excerpts, ordering).

Reuses the existing extractor: the HTML→markdown conversion that already backs `sdk-context.txt` / `fhir-context.txt` is moved into a new importable `context_extractor.py` module and shared by both `generate-context.py` and `generate-llms.py` (a hyphenated filename can't be imported, hence the module). `generate-context.py`'s output is byte-for-byte unchanged — verified by running it and diffing.

Amplify changes:
- installs `uv` in `preBuild` and puts it on the PATH so `yarn build` can run the generator
- serves `.md` as `text/markdown; charset=utf-8` (so they render instead of downloading)
- marks the `.md` / `llms*.txt` artifacts `noindex` so they don't compete with the canonical HTML pages in search

The older `sdk-context.txt` / `fhir-context.txt` (used by the Canvas Plugin Assistant) are untouched and still committed by `generate-context.py` via its existing workflow.

## Testing

Ran `generate-llms.py` against a built `_site` locally: 725 `.md` mirrors, a spec-shaped `llms.txt`, and a 3 MB `llms-full.txt`, with links resolving to the mirror files. Also re-ran the refactored `generate-context.py` to confirm identical output (145 SDK + 64 FHIR pages, same `----- BEGIN PAGE` format). `ruff check` / `ruff format` clean.

No automated test is added: as with the two existing generator scripts, generation is exercised by the build itself (a failure fails the Amplify deploy). Happy to add a fixture-based unit test if we want one.