### PR TITLE
docs(api): third-party developer access page + align access policy with g(10)

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -25,6 +25,8 @@ api_canvas_fhir:
     url: /api/quickstart/
   - title: "Customer Authentication"
     url: /api/customer-authentication/
+  - title: "Third-Party Developer Access"
+    url: /api/developer-access/
   - title: Authentication Best Practices
     url: /api/authentication-best-practices/
   - title: "Conditional Requests"

--- a/collections/_api/developer-access.md
+++ b/collections/_api/developer-access.md
@@ -17,6 +17,13 @@ An individual patient authorizes your application to access **their own** health
 
 A practice or organization using Canvas as its EHR authorizes access to data across its patient population, typically through the client-credentials flow (`system/` context) and bulk export. This access is authorized by the practice or organization that holds the data.
 
+## One Canvas instance per customer
+
+Each Canvas customer runs its own isolated instance, with its own base URL and its own authorization server. There is no single shared endpoint that spans customers. For patient-directed access, as part of verification we register and enable your application on every Canvas instance that has a patient portal enabled. Two things follow:
+
+- **Discover instances from the published directory.** The [Service Base URLs](/api/service-base-urls/) directory lists each customer's FHIR base URL in a machine-readable FHIR R4 Bundle, so your application can present the right practice to a user and route requests to the correct instance.
+- **Patients authorize on their own practice's instance.** For patient-directed access, send the patient to the authorization endpoint of the instance where they are a patient. They sign in with that practice's patient portal credentials and consent, and the resulting token is scoped to that single patient. Access to a given practice requires that the practice has its patient portal enabled and that the individual has a login there.
+
 ## Requesting access
 
 Third-party developers do not need to be an existing Canvas customer to request access. To begin:

--- a/collections/_api/developer-access.md
+++ b/collections/_api/developer-access.md
@@ -1,0 +1,48 @@
+---
+title: "Third-Party Developer Access"
+layout: apipage
+---
+
+Canvas Medical is certified to ONC's [§170.315(g)(10)](/product-updates/rwt/) *Standardized API for Patient and Population Services*. This page describes how a third-party developer requests access to the FHIR API, the verification we perform, and the timelines we commit to under [45 CFR 170.404](https://www.ecfr.gov/current/title-45/section-170.404).
+
+## Two kinds of access
+
+The API supports two distinct access models. The authorization gate is different for each, and it is important to know which one your application needs.
+
+### Patient-directed access
+
+An individual patient authorizes your application to access **their own** health information. The patient authenticates and grants consent through the [SMART on FHIR](/api/customer-authentication/#smart-on-fhir-scopes) authorization-code flow, and the resulting token is scoped to that patient (`patient/` context). The patient's authorization is the only approval required — access does not depend on separate sign-off from the patient's practice.
+
+### Population and bulk access
+
+A practice or organization using Canvas as its EHR authorizes access to data across its patient population, typically through the client-credentials flow (`system/` context) and bulk export. This access is authorized by the practice or organization that holds the data.
+
+## Requesting access
+
+Third-party developers do not need to be an existing Canvas customer to request access. To begin:
+
+1. Contact us at {{CONFIRM: developer-access intake address}} with your organization name, a description of your application, the access model you need (patient-directed or population/bulk), and a technical point of contact.
+2. We complete an authenticity-verification review. This process is objective and applied uniformly to all API users, and we complete it within **ten business days** of receiving your request.
+3. Once verification is complete, we register and enable your application for production use within **five business days**.
+
+We do not condition access on fees or royalties for the rights the API Condition of Certification protects, non-compete or exclusive-dealing terms, unrelated licenses, transfer of your intellectual property, Canvas-specific testing or certification, or reciprocal access to your application's data.
+
+## Sandbox access
+
+We provision a sandbox so your team can build and test before production enablement. Request sandbox credentials as part of step 1 above. Sandbox base URLs follow the pattern `https://fumage-<sandbox-name>.canvasmedical.com`; see the [Quickstart](/api/quickstart/) for making your first request.
+
+## Registering your application
+
+Once you have access to an instance (sandbox or production), register your application and obtain OAuth credentials by following [Customer Authentication](/api/customer-authentication/). That page documents the client-credentials and authorization-code flows and the available SMART scopes.
+
+## Fees
+
+{{CONFIRM: fee schedule and link}} Any permitted fees are limited to the recovery of costs reasonably incurred to develop, deploy, and host the certified API technology, consistent with 45 CFR 170.404(a). Fees, if any, are published in full so you can evaluate them before requesting access.
+
+## Service base URLs
+
+Canvas publishes service base URLs for its customers. See [Service Base URLs](/api/service-base-urls/).
+
+## Terms of Use
+
+Use of the API is governed by our [Terms of Use](/api/terms-of-use/).

--- a/collections/_api/developer-access.md
+++ b/collections/_api/developer-access.md
@@ -21,7 +21,7 @@ A practice or organization using Canvas as its EHR authorizes access to data acr
 
 Third-party developers do not need to be an existing Canvas customer to request access. To begin:
 
-1. Contact us at {{CONFIRM: developer-access intake address}} with your organization name, a description of your application, the access model you need (patient-directed or population/bulk), and a technical point of contact.
+1. Contact us at [developer-access@canvasmedical.com](mailto:developer-access@canvasmedical.com) with your organization name, a description of your application, the access model you need (patient-directed or population/bulk), and a technical point of contact.
 2. We complete an authenticity-verification review. This process is objective and applied uniformly to all API users, and we complete it within **ten business days** of receiving your request.
 3. Once verification is complete, we register and enable your application for production use within **five business days**.
 

--- a/collections/_api/developer-access.md
+++ b/collections/_api/developer-access.md
@@ -27,6 +27,16 @@ Third-party developers do not need to be an existing Canvas customer to request 
 
 We do not condition access on fees or royalties for the rights the API Condition of Certification protects, non-compete or exclusive-dealing terms, unrelated licenses, transfer of your intellectual property, Canvas-specific testing or certification, or reciprocal access to your application's data.
 
+## What we verify
+
+Verification confirms the authenticity of your organization and your application. It is limited to identity and does not evaluate the merits of your product. We apply the same criteria to every API user. You provide:
+
+- **Organization identity** — your registered legal business name and a verifiable business identifier, such as control of your organization's domain, a state business registration, or a D-U-N-S number.
+- **A domain-verified contact** — a named representative reachable at an email address on your organization's domain who can act on the organization's behalf.
+- **Application details** — the application name, a description of its intended use, the access model (patient-directed or population/bulk), and the redirect URIs or registered endpoints it will use.
+- **Attestations** — that the application has a published privacy policy and terms, that it will access data only as authorized by the patient (patient-directed access) or the organization (population/bulk access), and that you will comply with applicable law.
+- **Agreement to our [Terms of Use](/api/terms-of-use/).**
+
 ## Sandbox access
 
 We provision a sandbox so your team can build and test before production enablement. Request sandbox credentials as part of step 1 above. Sandbox base URLs follow the pattern `https://fumage-<sandbox-name>.canvasmedical.com`; see the [Quickstart](/api/quickstart/) for making your first request.
@@ -37,7 +47,7 @@ Once you have access to an instance (sandbox or production), register your appli
 
 ## Fees
 
-{{CONFIRM: fee schedule and link}} Any permitted fees are limited to the recovery of costs reasonably incurred to develop, deploy, and host the certified API technology, consistent with 45 CFR 170.404(a). Fees, if any, are published in full so you can evaluate them before requesting access.
+There is no fee to register, verify, or enable a third-party application for access to the API.
 
 ## Service base URLs
 

--- a/collections/_api/index.md
+++ b/collections/_api/index.md
@@ -16,7 +16,7 @@ There is a [Bruno](https://www.usebruno.com/) Collection that allows easy access
     <img src="https://fetch.usebruno.com/button.svg" alt="Fetch in Bruno" style="width: 130px; height: 30px;" width="128" height="32"></a>
 
 ## Who can access this API?
-While Canvas intends to make portions of this API accessible to third-parties in the near future (with patient authorization), it is currently limited to practices and organizations utilizing Canvas Medical as their EHR as well as their trusted partners.
+Canvas Medical is certified to ONC's §170.315(g)(10) Standardized API. Patients can authorize third-party applications to access their own health information through the SMART on FHIR authorization flow, and organizations using Canvas as their EHR can access the API for their own operational use. Third-party developers can request access following the process described in [Third-Party Developer Access](/api/developer-access/).
 
 ## Terms of Use
 You can access our full terms of use [here](/api/terms-of-use)

--- a/collections/_api/index.md
+++ b/collections/_api/index.md
@@ -16,7 +16,11 @@ There is a [Bruno](https://www.usebruno.com/) Collection that allows easy access
     <img src="https://fetch.usebruno.com/button.svg" alt="Fetch in Bruno" style="width: 130px; height: 30px;" width="128" height="32"></a>
 
 ## Who can access this API?
-Canvas Medical is certified to ONC's §170.315(g)(10) Standardized API. Patients can authorize third-party applications to access their own health information through the SMART on FHIR authorization flow, and organizations using Canvas as their EHR can access the API for their own operational use. Third-party developers can request access following the process described in [Third-Party Developer Access](/api/developer-access/).
+Canvas Medical is certified to ONC's §170.315(g)(10) Standardized API. There are three ways to access it:
+
+- **Practices and organizations using Canvas as their EHR** can access the API for their own patients and operations.
+- **Patients** can authorize third-party applications to access their own health information through the SMART on FHIR authorization flow.
+- **Third-party developers** can request access following the process described in [Third-Party Developer Access](/api/developer-access/).
 
 ## Terms of Use
 You can access our full terms of use [here](/api/terms-of-use)


### PR DESCRIPTION
Adds a **Third-Party Developer Access** page and rewrites the FHIR API landing page's "Who can access this API?" section so our published policy reflects that Canvas is certified to §170.315(g)(10) and is subject to the API Condition of Certification (45 CFR 170.404).

## Why

Our docs currently state that third-party patient-authorized access is a future intention and that the API "is currently limited to practices and organizations utilizing Canvas Medical as their EHR as well as their trusted partners." Because Canvas is g(10)-certified (certificate 15.04.04.3112.Canv.01.00.1.220523), that language reads as a gap against 170.404, which requires the certified API be available to API users without special effort. A prospective integrator flagged exactly this and cited the rule. There is no existing developer-onboarding page for an unaffiliated third party — registration today only happens inside a customer instance — so this adds one.

## Changes

- New page `collections/_api/developer-access.md`: the access-request process (intake at developer-access@canvasmedical.com), the objective authenticity-verification requirements, verification within ≤10 business days, production registration within ≤5 business days, sandbox provisioning, no access fee, the prohibited-conditions list from 170.404, and the patient-directed vs. population/bulk access distinction (patient authorization is the gate for the former, not per-practice sign-off).
- Rewrites the `index.md` "Who can access this API?" paragraph to point at the new page.
- Adds the page to the FHIR API sidebar in `_data/menus.yml`.

## For review

All placeholders are resolved: no access fee, and the "What we verify" section is a **proposed** authenticity-verification requirement set (objective, uniform, identity-only) for your / legal review before merge.

## Related process work (not in this PR)

- Terms of Use ("Developer Tools Agreement") only contemplate developers building "Connected Services" and forbid credential sharing; they do not contemplate an individual patient authorizing their own third-party app. Needs a legal pass.
- Stand up the actual intake + verification workflow behind the process this page documents (route developer-access@ to the right owners; wire up the verification and enablement steps).

## Confirmed already in place

- 170.404(b)(2) service base URL publication is satisfied: `/assets/static/fhir-service-base-urls-production.json` (and the nonproduction equivalent) are valid FHIR R4 Bundles pairing Organization + Endpoint resources, publicly served and linked from the Service Base URLs page. Open question is only freshness/automation — the current files are dated Oct 15 2025.