### PR TITLE
docs: fix Jekyll build warnings (empty slug, release-note collisions, scribe code blocks)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,6 +98,8 @@ plugins:
 
 ### Exclude from processing
 exclude:
+  - .devbox
+  - .venv
   - Gemfile
   - Gemfile.lock
   - README.md

--- a/collections/_api/index.md
+++ b/collections/_api/index.md
@@ -1,5 +1,5 @@
 ---
-slug: /
+permalink: /api/
 title: "Introduction "
 layout: apilandingpage
 ---

--- a/collections/_guides/index.md
+++ b/collections/_guides/index.md
@@ -1,5 +1,5 @@
 ---
-slug: /
+permalink: /guides/
 title: "Guides"
 layout: "landingpage"
 ---

--- a/collections/_guides/scribe-ai-parser.md
+++ b/collections/_guides/scribe-ai-parser.md
@@ -141,7 +141,7 @@ class Handler(BaseHandler):
 
 The `ScribeParser` delegates the parsing of each transcript section to specific section parsers.
 
-```python
+```python?partial=true
 from ai_scribe.parsers.base import TranscriptParser
 
 
@@ -175,7 +175,7 @@ class ScribeParser(TranscriptParser):
 #### 3. Section Parsers
 
 Each section parser extracts relevant information from its section and produces commands.
-```python
+```python?partial=true
 from typing import Any, Sequence
 from ai_scribe.parsers.base import CommandParser, ParsedContent
 from canvas_sdk.commands.commands.plan import PlanCommand
@@ -195,7 +195,7 @@ Suppose you want to parse the "Appointments" section into a `TaskCommand` for fo
 
 #### Define the Parser
 
-```python
+```python?partial=true
 from typing import Sequence, Any
 from canvas_sdk.commands import TaskCommand
 from ai_scribe.parsers.base import CommandParser, ParsedContent
@@ -232,7 +232,7 @@ class ScribeParser:
 
 To replace `ScribeParser`, define your custom parser.
 
-```python
+```python?partial=true
 from ai_scribe.parsers.base import (
     ParsedContent,
     TranscriptParser,

--- a/collections/_learn/index.md
+++ b/collections/_learn/index.md
@@ -1,5 +1,5 @@
 ---
-slug: /
+permalink: /learn/
 title: "Developer Education"
 layout: "educationlandingpage"
 hidden: true

--- a/collections/_release-notes/2023/2023-05-23-write-practitioner.md
+++ b/collections/_release-notes/2023/2023-05-23-write-practitioner.md
@@ -1,4 +1,5 @@
 ---
+slug: write-practitioner-2023-05-23
 title: Manage Staff with the FHIR Practitioner Create & Update Endpoints
 date: 2024-05-23
 tags: api

--- a/collections/_release-notes/2023/2023-12-29-note-api-updates.md
+++ b/collections/_release-notes/2023/2023-12-29-note-api-updates.md
@@ -1,4 +1,5 @@
 ---
+slug: note-api-updates-2023-12-29
 title: Enhancements to Note API 
 date: 2023-12-29
 tags: beta api

--- a/collections/_release-notes/2024/2024 Q1/2024-02-08-addtl-beta-commands.md
+++ b/collections/_release-notes/2024/2024 Q1/2024-02-08-addtl-beta-commands.md
@@ -1,4 +1,5 @@
 ---
+slug: addtl-beta-commands-2024-02-08
 title: New Commands Added to Commands Module
 date: 2024-02-08
 layout: productupdates

--- a/collections/_release-notes/2024/2024 Q1/2024-03-06-write-labs.md
+++ b/collections/_release-notes/2024/2024 Q1/2024-03-06-write-labs.md
@@ -1,4 +1,5 @@
 ---
+slug: write-labs-2024-03-06
 title: Write Labs Via the API
 date: 2024-03-06
 layout: productupdates

--- a/collections/_release-notes/2024/2024 Q2/2024-05-30-admin-improvements.md
+++ b/collections/_release-notes/2024/2024 Q2/2024-05-30-admin-improvements.md
@@ -1,4 +1,5 @@
 ---
+slug: admin-improvements-2024-05-30
 title: Admin Improvements
 layout: productupdates
 tags: config

--- a/collections/_release-notes/2024/2024 Q2/2024-06-04-beta-commands.md
+++ b/collections/_release-notes/2024/2024 Q2/2024-06-04-beta-commands.md
@@ -1,4 +1,5 @@
 ---
+slug: beta-commands-2024-06-04
 title: New Commands Added to Commands Module
 date: 2024-06-03
 layout: productupdates

--- a/collections/_release-notes/2024/2024 Q3/2024-07-11-commands-beta.md
+++ b/collections/_release-notes/2024/2024 Q3/2024-07-11-commands-beta.md
@@ -1,4 +1,5 @@
 ---
+slug: commands-beta-2024-07-11
 title: SDK Allergy, Remove Allergy, and Family History Commands Available for Beta Testing
 tags: beta sdk
 date: 2024-07-11

--- a/collections/_release-notes/2024/2024 Q4/2024-12-12-move-commands.md
+++ b/collections/_release-notes/2024/2024 Q4/2024-12-12-move-commands.md
@@ -1,4 +1,5 @@
 ---
+slug: move-commands-2024-12-12
 title: Move Uncommitted Commands
 tags: beta ui
 date: 2024-12-12

--- a/collections/_release-notes/2025 Q1/2025-01-30-cursor-focus.md
+++ b/collections/_release-notes/2025 Q1/2025-01-30-cursor-focus.md
@@ -1,4 +1,5 @@
 ---
+slug: cursor-focus-2025-01-30
 title: Maintains Cursor Focus when Adding Commands
 date: 2025-01-30 20:00:00
 tags: ui

--- a/collections/_release-notes/2025 Q1/2025-02-07-cursor-focus.md
+++ b/collections/_release-notes/2025 Q1/2025-02-07-cursor-focus.md
@@ -1,4 +1,5 @@
 ---
+slug: cursor-focus-2025-02-07
 title: Fixes Cursor Focus Bug in SDK Command Handling  
 layout: productupdates  
 tags: bugfix ui

--- a/collections/_release-notes/2025-06-02-release-notes.md
+++ b/collections/_release-notes/2025-06-02-release-notes.md
@@ -1,4 +1,5 @@
 ---
+slug: release-notes-2025-06-02
 title: 06.02.2025
 layout: productupdates  
 tags: bugfix plugins

--- a/collections/_release-notes/2025-09-26-coverage-breaking-change.md
+++ b/collections/_release-notes/2025-09-26-coverage-breaking-change.md
@@ -1,4 +1,5 @@
 ---
+slug: coverage-breaking-change-2025-09-26
 title: Upcoming Breaking Change - Coverage Subscriber ID
 date: 2025-09-26 08:00:00
 layout: productupdates

--- a/collections/_sdk/index.md
+++ b/collections/_sdk/index.md
@@ -1,5 +1,5 @@
 ---
-slug: /
+permalink: /sdk/
 title: "The Canvas SDK"
 layout: sdk
 ---


### PR DESCRIPTION
- Landing pages (api/guides/learn/sdk): use explicit permalink instead of
  slug: / (which slugified to empty and warned)
- Release notes: add date-based slugs to older duplicate-named notes so
  each output path is unique (keeps the newest/live URL unchanged)
- scribe-ai-parser: mark ai_scribe-importing blocks as partial so the
  code-block check skips the non-installable plugin module

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>… scribe code blocks)

- Landing pages (api/guides/learn/sdk): use explicit permalink instead of
  slug: / (which slugified to empty and warned)
- Release notes: add date-based slugs to older duplicate-named notes so
  each output path is unique (keeps the newest/live URL unchanged)
- scribe-ai-parser: mark ai_scribe-importing blocks as partial so the
  code-block check skips the non-installable plugin module

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>