### PR TITLE
docs: document practice_location_override on PrescribeCommand.send (KOALA-6258)

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -139,6 +139,12 @@ Returns an Effect that sends a signed command.
 
 **Limited availability** The `send()` method can only be called on [LabOrder](#laborder) and [Prescribe](#prescribe) command objects. Other command types do not support this operation.
 
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `practice_location_override` | `str \| UUID` | No | `None` | [Prescribe](#prescribe) only. The `id` of a practice location whose address is used as the prescriber address on the outgoing prescription, overriding the prescriber's primary location. See [Prescribe](#prescribe) for behavior and limitations. |
+
 **Example**:
 
 ```python
@@ -148,6 +154,17 @@ def compute():
     existing_prescribe = PrescribeCommand(command_uuid='e32b85d9-ccb7-4e4f-a0e5-8783ed2d9528')
 
     return [existing_prescribe.send()]
+```
+
+To send the prescription using a specific practice location's address (see [Prescribe](#prescribe)):
+
+```python
+from canvas_sdk.commands import PrescribeCommand
+
+def compute():
+    existing_prescribe = PrescribeCommand(command_uuid='e32b85d9-ccb7-4e4f-a0e5-8783ed2d9528')
+
+    return [existing_prescribe.send(practice_location_override='a1b2c3d4-e5f6-7890-abcd-ef1234567890')]
 ```
 
 #### enter_in_error
@@ -1408,6 +1425,16 @@ command.set_test_value("pH", "6.8")
 
 - A pharmacy must be specified on the command before it can be sent.
 - The command must be committed/signed before it can be sent electronically.
+
+**Overriding the prescriber address:** By default, the prescriber address transmitted on the prescription is derived from the prescriber's primary practice location. For workflows where a provider works across multiple offices — for example white bagging, where the medication ships to the office where the patient is being seen — pass a `practice_location_override` to [`send()`](#send) to use a specific practice location's address instead:
+
+```python
+existing_prescribe.send(practice_location_override=location_id)
+```
+
+- `practice_location_override` is the `id` of a practice location. When set, that location's business name, phone, fax, and street address replace the prescriber's default on the outgoing prescription.
+- If the id does not correspond to an existing practice location, the send raises an error rather than falling back to the default address.
+- The override applies only to `send()`-initiated (plugin-driven) prescriptions. It does not affect prescriptions a clinician sends from the charting UI.
 
 
 **Command-specific parameters**:

--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -1429,7 +1429,12 @@ command.set_test_value("pH", "6.8")
 **Overriding the prescriber address:** By default, the prescriber address transmitted on the prescription is derived from the prescriber's primary practice location. For workflows where a provider works across multiple offices — for example white bagging, where the medication ships to the office where the patient is being seen — pass a `practice_location_override` to [`send()`](#send) to use a specific practice location's address instead:
 
 ```python
-existing_prescribe.send(practice_location_override=location_id)
+from canvas_sdk.commands import PrescribeCommand
+
+def compute():
+    existing_prescribe = PrescribeCommand(command_uuid='e32b85d9-ccb7-4e4f-a0e5-8783ed2d9528')
+
+    return [existing_prescribe.send(practice_location_override='a1b2c3d4-e5f6-7890-abcd-ef1234567890')]
 ```
 
 - `practice_location_override` is the `id` of a practice location. When set, that location's business name, phone, fax, and street address replace the prescriber's default on the outgoing prescription.


### PR DESCRIPTION
[KOALA-6258](https://canvasmedical.atlassian.net/browse/KOALA-6258)

## Summary

Documents the new `practice_location_override` argument on `PrescribeCommand.send()`, which lets a plugin choose the practice location that drives the prescriber address on an outgoing Surescripts prescription (for white-bagging and multi-location workflows).

## Implementation

Adds the parameter to the SDK command reference in two places: a `**Parameters:**` table on the generic `send()` method, and an "Overriding the prescriber address" subsection in the Prescribe command's electronic-prescribing notes, with a usage example. The docs state the behavior plainly — it raises on a nonexistent location id, and applies only to plugin-initiated sends of non-controlled prescriptions (not the charting UI or EPCS/controlled substances).

Documents the SDK change in canvas-plugins PR #1787.

[KOALA-6258]: https://canvasmedical.atlassian.net/browse/KOALA-6258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ