### PR TITLE
docs(simple-api): authenticating as a Canvas user with Bearer tokens

### DIFF
--- a/collections/_sdk/handlers/simple-api/api.md
+++ b/collections/_sdk/handlers/simple-api/api.md
@@ -765,3 +765,27 @@ class MyAPI(PatientSessionAuthMixin, SimpleAPIRoute):
             JSONResponse({"message": "Hello world!"})
         ]
 ```
+
+## Acting as a Canvas user
+
+By default, a SimpleAPI request isn't tied to a specific person, so any effects it
+returns — such as creating, locking, or signing a note — are recorded as Canvas Bot
+rather than a clinician.
+
+To have a request run **as a specific Canvas staff member** — for example, so a note
+is signed under the treating provider's name — call the endpoint with an access token
+obtained through the
+[Authorization Code flow](/api/customer-authentication#authorization-code). That flow
+issues a token that represents the staff member who signed in and approved it. Send it
+as a Bearer token in the `Authorization` header, and Canvas identifies the user from
+the token and treats the request as coming from them, so any effects the handler
+returns are attributed to that staff member.
+
+```bash
+curl --request POST \
+  --url 'https://example.canvasmedical.com/plugin-io/api/my_plugin/note/<note-id>/sign' \
+  --header 'Authorization: Bearer <access-token>'
+```
+
+In this example the note is signed and recorded in Canvas as signed by the staff
+member who authorized the access token, not by Canvas Bot.


### PR DESCRIPTION
## What

Adds an **"Authenticating as a Canvas user"** note to the Bearer authentication section of the SimpleAPI HTTP handler docs (`/sdk/handlers-simple-api-http`).

It explains, in plain terms, that a Bearer token obtained via the **Authorization Code flow** acts as the signed-in staff member — so actions your endpoint performs (like signing or locking a note) are recorded in Canvas as done by that clinician. Links to the Authorization Code flow in Customer Authentication.

## Why

Came up in a developer-support investigation (SUPPORT-2282): a customer building a note create → sign/lock integration in a plugin needed notes attributed to the treating clinician, not the API/system identity. The supported answer is to authenticate the SimpleAPI request with an Authorization Code token for that clinician, but the Bearer docs didn't call this out. This makes the "act as a specific user" path discoverable.

## Notes
- Docs-only change; no code impact.
- Written from a Support Stack investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)