### PR TITLE
docs: add RefillRequest SDK data model

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -1133,6 +1133,9 @@ data_module:
   - title: "Referral"
     url: /sdk/data-referral/
     description: A referral directing a specific patient to another provider or specialist.
+  - title: "RefillRequest"
+    url: /sdk/data-refill-request/
+    description: An incoming request to refill a patient's medication and its responding prescriptions.
   - title: "ServiceProvider"
     url: /sdk/data-serviceprovider/
     description: Data associated with Service Providers.

--- a/collections/_sdk/data/prescription.md
+++ b/collections/_sdk/data/prescription.md
@@ -96,6 +96,7 @@ committed_prescriptions = Prescription.objects.committed()
 | previous_medication           | [Medication](/sdk/data-medication/)                  |
 | indications                   | [Assessment](/sdk/data-assessment/)[]                |
 | related_refill                | [Prescription](#prescription)                        |
+| refill_request                | [RefillRequest](/sdk/data-refill-request/)           |
 | status                        | [PrescriptionStatus](#prescriptionstatus)            |
 | response_type                 | [PrescriptionResponse](#prescriptionresponse)        |
 | is_refill                     | Boolean                                              |

--- a/collections/_sdk/data/refill_request.md
+++ b/collections/_sdk/data/refill_request.md
@@ -1,0 +1,100 @@
+---
+title: "RefillRequest"
+slug: "data-refill-request"
+excerpt: "Canvas SDK RefillRequest"
+hidden: false
+---
+
+## Introduction
+
+The `RefillRequest` model represents an incoming request to refill a patient's medication — for example, a renewal request received electronically from a pharmacy. Each request carries the raw request payload in its `content` attribute, the associated patient and staff member, the medication codings that describe the requested drug (`RefillRequestCoding`), and the prescription(s) written in response.
+
+## Basic usage
+
+To get a refill request by identifier, use the `get` method on the `RefillRequest` model manager:
+
+```python
+from canvas_sdk.v1.data.refill_request import RefillRequest
+
+refill_request = RefillRequest.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
+```
+
+If you have a patient object, the refill requests for a patient can be accessed with the `refill_requests` attribute on a `Patient` object:
+
+```python
+from canvas_sdk.v1.data.patient import Patient
+
+patient = Patient.objects.get(id="1eed3ea2a8d546a1b681a2a45de1d790")
+refill_requests = patient.refill_requests.all()
+```
+
+If you have a patient ID, you can get the refill requests for the patient with the `for_patient` method on the `RefillRequest` model manager:
+
+```python
+from canvas_sdk.v1.data.refill_request import RefillRequest
+
+patient_id = "1eed3ea2a8d546a1b681a2a45de1d790"
+refill_requests = RefillRequest.objects.for_patient(patient_id)
+```
+
+## Filtering
+
+Refill requests can be filtered by any attribute that exists on the model.
+
+Filtering is done with the `filter` method on the `RefillRequest` model manager.
+
+### By attribute
+
+Specify an attribute with `filter` to filter by that attribute:
+
+```python
+from canvas_sdk.v1.data.refill_request import RefillRequest
+
+outstanding_requests = RefillRequest.objects.filter(ignored=False)
+```
+
+## Related data
+
+A refill request's medication codings are available through the `codings` reverse relation, and the prescriptions written in response are available through the `response` reverse relation:
+
+```python
+from canvas_sdk.v1.data.refill_request import RefillRequest
+
+refill_request = RefillRequest.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
+codings = refill_request.codings.all()
+responding_prescriptions = refill_request.response.all()
+```
+
+## Attributes
+
+### RefillRequest
+
+| Field Name | Type                                                     |
+|------------|----------------------------------------------------------|
+| id         | UUID                                                     |
+| dbid       | Integer                                                  |
+| created    | DateTime                                                 |
+| modified   | DateTime                                                 |
+| patient    | [Patient](/sdk/data-patient/)                            |
+| staff      | [Staff](/sdk/data-staff/)                                |
+| message_id | String                                                   |
+| ignored    | Boolean                                                  |
+| content    | JSON                                                     |
+| codings    | [RefillRequestCoding](#refillrequestcoding)[]            |
+| response   | [Prescription](/sdk/data-prescription/#prescription)[]   |
+
+### RefillRequestCoding
+
+| Field Name     | Type                              |
+|----------------|-----------------------------------|
+| dbid           | Integer                           |
+| refill_request | [RefillRequest](#refillrequest)   |
+| system         | String                            |
+| version        | String                            |
+| code           | String                            |
+| display        | String                            |
+| user_selected  | Boolean                           |
+
+<br/>
+<br/>
+<br/>


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6505

## What

Adds SDK data-module documentation for the newly exposed `RefillRequest` and `RefillRequestCoding` models:

- **New page** `collections/_sdk/data/refill_request.md` — intro, basic usage (`get`, `patient.refill_requests`, `for_patient`), attribute filtering, the `codings` and `response` reverse relations, and attribute tables for both models. Mirrors the structure/conventions of the sibling `referral.md` and `prescription.md` pages.
- **Sidebar** `_data/menus.yml` — new "RefillRequest" entry (alphabetical, after "Referral").
- **Cross-link** `collections/_sdk/data/prescription.md` — adds the new `refill_request` foreign key to the `Prescription` attribute table (this FK is the crux of the ticket; `refill_request.response` returns the responding prescriptions).

Attribute tables were verified field-for-field against the SDK model source in canvas-plugins#1795.

## Ticket & related PRs

Documents the change from **KOALA-6505** — "Expose RefillRequest to the Canvas SDK data module":

- SDK models: canvas-medical/canvas-plugins#1795
- home-app database views: canvas-medical/canvas#19382

## ⚠️ Merge ordering / CI

The `test-code-blocks` job **executes** the imports in the Python examples (`exec` in `test-code-blocks.py`). The docs site pins `canvas` from `canvas-plugins@main`, so `from canvas_sdk.v1.data.refill_request import ...` will raise `ModuleNotFoundError` until **canvas-plugins#1795 is merged to `main`**.

**This PR should merge after canvas-plugins#1795.** Once that lands, the docs CI resolves the new module and all example blocks pass. The code blocks are otherwise structurally valid — the local validator reports no syntax or missing-reference errors, only the expected "module not released yet" `ModuleNotFoundError` (same class as existing pre-release failures already present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)