### PR TITLE
Add security documentation: platform overview, plugin security model, audit logging, roles and permissions

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -661,6 +661,10 @@ guides_list:
     url: /guides/audit-logging-and-telemetry/
     description: What Canvas audits, how long it is retained, and how to export it
 
+  - title: "Roles and Permissions"
+    url: /guides/roles-and-permissions/
+    description: How authorization is evaluated, the default roles, and how to extend them
+
 guides_templates:
   - title: "Behavioral Health"
     url: /guides/bh/

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -647,6 +647,20 @@ guides_list:
     uses:
       - sdk
 
+  - title: "Platform Security Overview"
+    url: /guides/platform-security-overview/
+    description: Tenancy model, trust boundaries, platform controls, and shared responsibility
+
+  - title: "Plugin Security Model"
+    url: /guides/plugin-security-model/
+    description: How plugin code is isolated at runtime and governed on its way to production
+    uses:
+      - sdk
+
+  - title: "Audit Logging and Telemetry"
+    url: /guides/audit-logging-and-telemetry/
+    description: What Canvas audits, how long it is retained, and how to export it
+
 guides_templates:
   - title: "Behavioral Health"
     url: /guides/bh/

--- a/collections/_guides/audit-logging-and-telemetry.md
+++ b/collections/_guides/audit-logging-and-telemetry.md
@@ -1,0 +1,100 @@
+---
+title: "Audit Logging and Telemetry"
+---
+
+Canvas records an attributed audit trail of activity in your instance and makes it
+available to you through several export paths. This page describes what is captured, how
+long it is retained, and how to get it out — whether for an internal investigation, a
+compliance review, or ingestion into your own SIEM.
+
+## What is captured
+
+Canvas maintains a per-record audit trail. Each entry identifies the record type acted
+on, the action taken, the acting user, the patient context where applicable, and a UTC
+timestamp.
+
+| Action | Captured | Granularity |
+| --- | --- | --- |
+| Create | Yes | Per record, per model, attributed to the acting user |
+| Edit or change | Yes | Per record, with full authorship history |
+| Delete, void, or enter-in-error | Yes | Per record, covering hard deletion, soft deletion, and marking entered-in-error |
+| Print | Yes | Note-print events |
+| Chart access | Yes | Chart-open events, attributed to the user opening the chart |
+
+Individual record reads within an already-opened chart are not enumerated separately;
+chart access is recorded at the point the chart is opened.
+
+Alongside the record audit trail, Canvas captures:
+
+- **Authentication events** — sign-in successes and failures, and account lockouts.
+- **Administrative activity** — configuration and permission changes, surfaced in the
+  admin console and protected there against edit and deletion.
+- **Staff activity reports** — generated nightly.
+
+### Change history through FHIR Provenance
+
+Authorship and change history are also exposed as FHIR `Provenance` resources across
+supported resource types, giving you a queryable record of who created or revised a
+resource and when. See the [Provenance API](/api/provenance/) reference for supported
+resource types and query parameters.
+
+Clinical notes additionally carry in-application revision history, visible to users
+directly in the chart.
+
+## Retention
+
+Audit records are retained in the live, queryable index for **90 days**. Older indices
+are archived to durable object storage and remain recoverable well beyond that window.
+If you require retrieval of archived records, contact Canvas support with the date range
+you need.
+
+Retention requirements that exceed the live window are best served by exporting on a
+schedule into your own retention tier — see the export paths below.
+
+## Getting audit data out
+
+Four supported paths exist today. Which one fits depends on whether you need a
+point-in-time extract, an ongoing feed, or ad-hoc investigation.
+
+| Path | Best for | Interface |
+| --- | --- | --- |
+| Audit Report export | Point-in-time extract of administrative and record-level audit events | Admin console |
+| FHIR Provenance API | Authorship and change history for specific resources | FHIR API |
+| FHIR Bulk Data export | Large-scale structured extraction | FHIR API — see [EHI Export](/documentation/ehi-export/) |
+| Read-only replica database | Ad-hoc investigation, custom reporting, scheduled ingestion | SQL |
+
+### Audit Report export
+
+The Audit Report is generated from the admin console and exports the audit trail for a
+selected date range. This is the most direct route to the record-level events described
+above.
+
+{% include alert.html type="warning" content="Audit Report access is permission-based. If you need access, your internal administrators can work with Canvas support to assign it to the appropriate groups." %}
+
+### Read-only replica database
+
+Instances can be provisioned with a read-only replica for direct SQL access. This is the
+most flexible path for building custom audit reporting or a scheduled extract into an
+external system, and it is the recommended interim approach for teams that want a
+continuous feed today.
+
+## Streaming to a SIEM
+
+Native push-based streaming to a customer-controlled destination, delivering events as
+JSON over HTTP, is in active development. If you are planning a SIEM integration, contact
+your Canvas representative — we can share the event schema and transport details, and
+help you design an interim feed from the replica database or the export APIs so your
+ingestion pipeline does not need to be rebuilt later.
+
+## Plugin activity
+
+Plugins execute in an isolated runner, and their activity is instrumented per plugin,
+including outbound HTTP calls made through the SDK. Plugins can also emit their own
+application logs — see [Plugin Logs](/sdk/plugin-logs/).
+
+## Related
+
+- [Platform Security Overview](/guides/platform-security-overview/)
+- [Plugin Security Model](/guides/plugin-security-model/)
+- [Provenance API](/api/provenance/)
+- [EHI Export](/documentation/ehi-export/)

--- a/collections/_guides/audit-logging-and-telemetry.md
+++ b/collections/_guides/audit-logging-and-telemetry.md
@@ -82,9 +82,7 @@ continuous feed today.
 
 Native push-based streaming to a customer-controlled destination, delivering events as
 JSON over HTTP, is in active development. If you are planning a SIEM integration, contact
-your Canvas representative — we can share the event schema and transport details, and
-help you design an interim feed from the replica database or the export APIs so your
-ingestion pipeline does not need to be rebuilt later.
+your Canvas representative.
 
 ## Plugin activity
 

--- a/collections/_guides/audit-logging-and-telemetry.md
+++ b/collections/_guides/audit-logging-and-telemetry.md
@@ -95,6 +95,7 @@ application logs — see [Plugin Logs](/sdk/plugin-logs/).
 ## Related
 
 - [Platform Security Overview](/guides/platform-security-overview/)
+- [Roles and Permissions](/guides/roles-and-permissions/)
 - [Plugin Security Model](/guides/plugin-security-model/)
 - [Provenance API](/api/provenance/)
 - [EHI Export](/documentation/ehi-export/)

--- a/collections/_guides/platform-security-overview.md
+++ b/collections/_guides/platform-security-overview.md
@@ -1,0 +1,96 @@
+---
+title: "Platform Security Overview"
+---
+
+This page describes how Canvas is deployed, where its trust boundaries sit, and which
+security controls are in force before any plugin, integration, or custom code is
+introduced. It is intended for security and compliance teams evaluating Canvas, and for
+implementers who need to know which controls they inherit and which they own.
+
+Canvas holds HITRUST CSF r2 certification. The certification report, SOC-equivalent
+artifacts, and the most recent independent penetration test are available under NDA
+through your Canvas contact.
+
+## Deployment and tenancy model
+
+Every Canvas customer runs on a **dedicated instance**: its own set of immutable
+application containers and its own database. Customer data is separated at the database
+level rather than by a row- or column-scoped partition inside a shared store, so there is
+no query path from one customer's application to another customer's data.
+
+Instances are hosted on Aptible, which runs on AWS in `us-east-1`, inside a segregated
+virtual private cloud. Application containers are rebuilt from a pinned image on each
+deploy rather than mutated in place.
+
+## Trust boundaries
+
+Requests cross five boundaries, each of which enforces its own controls:
+
+| Boundary | Responsibility |
+| --- | --- |
+| Edge | TLS termination, IP allow-listing, rate limiting, WAF and DDoS protection |
+| Core application | Authentication, session handling, role- and object-level authorization |
+| Plugin runner | Isolated execution of customer plugin code — see [Plugin Security Model](/guides/plugin-security-model/) |
+| FHIR API | Scoped, token-based access with patient-context enforcement |
+| Per-customer database | Tenant-isolated persistence, encrypted at rest |
+
+## Platform controls
+
+These apply to every instance and are not customer-configurable.
+
+### Encryption
+
+Traffic to and between Canvas services is encrypted with TLS. Databases and disk volumes
+are encrypted at rest with AES-256. Patient documents stored in object storage are
+encrypted at rest with AES-256 server-side encryption.
+
+### Identity and authentication
+
+Canvas supports SSO via SAML, with multi-factor authentication enforced by your identity
+provider. Failed-login lockout is applied to interactive sessions. Where an instance uses
+Canvas-managed credentials rather than SSO, password policy — including minimum length,
+complexity, and screening against known-breached and commonly-used passwords — is
+enforced centrally.
+
+### Authorization
+
+Access is governed by role-based access control. Permissions are evaluated at two levels:
+
+- **Model permissions** determine which record types a user may read or modify.
+- **Object permissions** narrow that further to specific records, scoped by patient group.
+
+Both are administered through roles and groups rather than granted to individuals
+directly.
+
+### Network
+
+Each instance's externally reachable endpoints carry IP allow-lists backed by cloud
+security groups. Internal services are not exposed to the public internet. Administrative
+access to Canvas infrastructure requires authentication through the corporate identity
+provider and traverses a VPN.
+
+### Privileged access
+
+Access to production containers is restricted by role. Sessions are recorded end to end,
+and the resulting logs are retained and reviewable.
+
+## Shared responsibility
+
+Canvas operates the platform and its controls. The following remain with the customer:
+
+| Area | Customer responsibility |
+| --- | --- |
+| Identity | Enforcing MFA, provisioning and deprovisioning users, periodic access review |
+| Authorization | Assigning roles and groups according to least privilege |
+| Plugins and extensions | Reviewing and approving code deployed to your instance — see [Plugin Security Model](/guides/plugin-security-model/) |
+| Credentials | Custody of API keys, OAuth client secrets, and plugin secrets |
+| Exported data | Protecting data once it leaves Canvas through an API, export, or replica |
+
+{% include alert.html type="info" content="Canvas can configure your instance so that plugins reach production only through a release pipeline you control. See Deployment governance in the Plugin Security Model guide." %}
+
+## Related
+
+- [Plugin Security Model](/guides/plugin-security-model/)
+- [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/)
+- [Customer Authentication](/api/customer-authentication/)
+- [Authentication Best Practices](/api/authentication-best-practices/)

--- a/collections/_guides/platform-security-overview.md
+++ b/collections/_guides/platform-security-overview.md
@@ -86,7 +86,7 @@ Canvas operates the platform and its controls. The following remain with the cus
 | Credentials | Custody of API keys, OAuth client secrets, and plugin secrets |
 | Exported data | Protecting data once it leaves Canvas through an API, export, or replica |
 
-{% include alert.html type="info" content="Canvas can configure your instance so that plugins reach production only through a release pipeline you control. See Deployment governance in the Plugin Security Model guide." %}
+{% include alert.html type="info" content="Installing a plugin requires a credential your organization controls, so your own review process can gate what reaches production. See Deployment governance in the Plugin Security Model guide." %}
 
 ## Related
 

--- a/collections/_guides/platform-security-overview.md
+++ b/collections/_guides/platform-security-overview.md
@@ -91,6 +91,7 @@ Canvas operates the platform and its controls. The following remain with the cus
 ## Related
 
 - [Plugin Security Model](/guides/plugin-security-model/)
+- [Roles and Permissions](/guides/roles-and-permissions/)
 - [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/)
 - [Customer Authentication](/api/customer-authentication/)
 - [Authentication Best Practices](/api/authentication-best-practices/)

--- a/collections/_guides/plugin-security-model.md
+++ b/collections/_guides/plugin-security-model.md
@@ -1,0 +1,112 @@
+---
+title: "Plugin Security Model"
+guide_for:
+- /sdk/
+---
+
+Plugins let you extend Canvas with your own logic. Because that logic runs inside a
+system holding patient data, the plugin runtime is deliberately constrained. This page
+describes those constraints and the deployment controls available to you, so your
+security team can evaluate what plugin code can and cannot do.
+
+## Execution model
+
+Plugins do not manipulate Canvas data directly. They **subscribe to events** and **return
+declarative effects** that the platform interprets and applies.
+
+That indirection is the core of the model. A plugin describes an intended outcome — add a
+banner, create a command, send a notification — and the platform decides whether and how
+to carry it out, applying the same validation and permission rules it applies to any
+other write. A plugin cannot reach past the effect layer to mutate records itself.
+
+## Runtime isolation
+
+The plugin runner executes customer code under several layers of containment:
+
+- **Process and user isolation.** Plugin code runs in a separate operating-system user
+  and process from the core application.
+- **Restricted interpreter.** Code executes in a RestrictedPython sandbox with an
+  explicit allowlist of importable modules. Modules outside that list are rejected at
+  load time, not at run time.
+- **No direct system access.** Plugins have no direct database connection, no filesystem
+  access, and no operating-system access.
+- **Constrained network surface.** Outbound communication is limited to HTTP and HTTPS
+  through the SDK's supported clients. Raw sockets and non-HTTP protocol libraries are
+  not available in the sandbox.
+- **Package integrity.** Plugin packages are checksummed, and the manifest is validated
+  before a plugin is installed.
+
+Because the module allowlist is enforced when the plugin is loaded, a plugin that
+attempts a disallowed import fails to install rather than failing partway through a
+patient-facing workflow.
+
+## Secrets
+
+Plugins declare the secrets they need in their manifest, and values are supplied per
+instance. Secret values are **write-only** from the plugin author's perspective: they can
+be set and used at runtime, but not read back out through the interface used to configure
+them.
+
+Treat plugin secrets like any other production credential — scope them narrowly, and
+rotate them on the same cadence as the rest of your estate.
+
+## Data access declarations
+
+A plugin's manifest declares the data it expects to read and write. These declarations
+document the plugin's intended scope, which makes them useful during code review: a
+reviewer can compare what a plugin says it touches against what its handlers actually do,
+and treat a mismatch as a finding.
+
+The controls that constrain a plugin at runtime are the isolation boundaries above and
+the permissions of the context it executes in.
+
+## API access
+
+Where a plugin or external application reaches Canvas through the FHIR API, access is
+scoped by OAuth token, and patient-context enforcement applies to patient-scoped launches.
+See [Customer Authentication](/api/customer-authentication/) and
+[Authentication Best Practices](/api/authentication-best-practices/).
+
+## Deployment governance
+
+How plugin code reaches production is configurable per instance, and this is the primary
+control your organization holds over plugin risk.
+
+### Customer-gated release
+
+Canvas can configure your instance so that plugins are promoted to production **only**
+through a source repository and pipeline you control — your GitHub or GitLab
+organization, your reviewers, your CI checks. Under this configuration, direct
+installation is disabled, and no plugin code reaches your production environment without
+passing your own review and approval gate.
+
+{% include alert.html type="info" content="If your organization requires that all code entering production pass a documented human review, ask your Canvas representative to enable customer-gated release for your instance during onboarding." %}
+
+### Environment separation
+
+Instances are provisioned per environment, and release channels let you promote a plugin
+through a lower environment before it reaches production. Deploys are pinned to a
+specific commit, so what you reviewed is what runs.
+
+### Change tracking
+
+Plugin deployment activity is tracked, and plugin runtime activity is instrumented per
+plugin. Combined with the audit trail described in
+[Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/), this gives you a
+record of both what changed and what the plugin did.
+
+## Recommended practices
+
+- Enable customer-gated release, and disable direct installation, if your change-management
+  policy requires documented approval before code runs in production.
+- Review a plugin's manifest data-access declarations against its handlers as part of code
+  review.
+- Scope plugin secrets to the minimum required, and rotate them on your normal cadence.
+- Exercise plugins in a lower environment before promoting to production.
+
+## Related
+
+- [Platform Security Overview](/guides/platform-security-overview/)
+- [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/)
+- [Your First Plugin](/guides/your-first-plugin/)
+- [Plugin Logs](/sdk/plugin-logs/)

--- a/collections/_guides/plugin-security-model.md
+++ b/collections/_guides/plugin-security-model.md
@@ -107,6 +107,7 @@ record of both what changed and what the plugin did.
 ## Related
 
 - [Platform Security Overview](/guides/platform-security-overview/)
+- [Roles and Permissions](/guides/roles-and-permissions/)
 - [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/)
 - [Your First Plugin](/guides/your-first-plugin/)
 - [Plugin Logs](/sdk/plugin-logs/)

--- a/collections/_guides/plugin-security-model.md
+++ b/collections/_guides/plugin-security-model.md
@@ -50,16 +50,6 @@ them.
 Treat plugin secrets like any other production credential — scope them narrowly, and
 rotate them on the same cadence as the rest of your estate.
 
-## Data access declarations
-
-A plugin's manifest declares the data it expects to read and write. These declarations
-document the plugin's intended scope, which makes them useful during code review: a
-reviewer can compare what a plugin says it touches against what its handlers actually do,
-and treat a mismatch as a finding.
-
-The controls that constrain a plugin at runtime are the isolation boundaries above and
-the permissions of the context it executes in.
-
 ## API access
 
 Where a plugin or external application reaches Canvas through the FHIR API, access is
@@ -69,18 +59,24 @@ See [Customer Authentication](/api/customer-authentication/) and
 
 ## Deployment governance
 
-How plugin code reaches production is configurable per instance, and this is the primary
-control your organization holds over plugin risk.
+### Who can install
 
-### Customer-gated release
+Installing or updating a plugin is an authenticated operation: it requires an OAuth token
+carrying the plugin scope for your instance. Controlling who holds that credential is the
+primary control over what reaches your production environment, and it is a control your
+organization owns.
 
-Canvas can configure your instance so that plugins are promoted to production **only**
-through a source repository and pipeline you control — your GitHub or GitLab
-organization, your reviewers, your CI checks. Under this configuration, direct
-installation is disabled, and no plugin code reaches your production environment without
-passing your own review and approval gate.
+### Installing from your own pipeline
 
-{% include alert.html type="info" content="If your organization requires that all code entering production pass a documented human review, ask your Canvas representative to enable customer-gated release for your instance during onboarding." %}
+Most organizations keep plugin source in their own repository and install from their own
+continuous-integration pipeline rather than from individual workstations. Under that
+arrangement the installing credential lives in CI, and your existing review process —
+pull-request approval, required checks, protected branches — is what gates production.
+
+Canvas recommends this pattern where your change-management policy requires documented
+human review before code runs in production.
+
+{% include alert.html type="info" content="Plugins built through Canvas Studio follow their own staged workflow, with explicit approval steps before a project is published." %}
 
 ### Environment separation
 
@@ -97,10 +93,8 @@ record of both what changed and what the plugin did.
 
 ## Recommended practices
 
-- Enable customer-gated release, and disable direct installation, if your change-management
-  policy requires documented approval before code runs in production.
-- Review a plugin's manifest data-access declarations against its handlers as part of code
-  review.
+- Hold the installing credential in CI rather than on workstations, so your pull-request
+  review is what gates production.
 - Scope plugin secrets to the minimum required, and rotate them on your normal cadence.
 - Exercise plugins in a lower environment before promoting to production.
 

--- a/collections/_guides/roles-and-permissions.md
+++ b/collections/_guides/roles-and-permissions.md
@@ -1,0 +1,131 @@
+---
+title: "Roles and Permissions"
+---
+
+Access in Canvas is governed by role-based access control. This page explains how
+authorization is evaluated, describes the roles every instance is provisioned with, and
+outlines how to extend them for your organization.
+
+## How authorization works
+
+Canvas evaluates two independent levels of permission on every request.
+
+**Model permissions** determine which record types a user may act on, and which actions
+are allowed on each: view, add, change, or delete. A user who lacks the view permission
+on a record type cannot read it anywhere in the application, including through the API.
+
+**Object permissions** narrow that further to specific records. Object scope is expressed
+through **patient groups**: a user may hold a permission on a record type in general but
+only exercise it for patients within the groups assigned to them. This is how an
+organization restricts a clinician to a panel, a site, or a program rather than the whole
+patient population.
+
+Both levels are always evaluated together. A user must satisfy the model permission and
+the object permission — and be an active user — for access to be granted.
+
+{% include alert.html type="info" content="Permissions are granted to roles, never directly to individuals. Adding or removing a user's access means changing their role assignments, which makes access reviews a question of who holds which role rather than an audit of per-user exceptions." %}
+
+Some capabilities are gated by **named feature permissions** rather than by a record type
+— printing, revenue, data integration, campaigns, the questionnaire builder, patient
+activation, and prescription cancellation among them. These behave identically in
+evaluation; they simply gate a feature rather than a model.
+
+## Default roles
+
+Every Canvas instance is provisioned with the roles below. They are grouped here by what
+they are for; in the admin console they appear as a flat list.
+
+### Broad functional roles
+
+| Role | Grants |
+| --- | --- |
+| Administrative | Organization and practice-location configuration, staff records, note types, letter and questionnaire templates, and revenue configuration |
+| Clinical | Clinical configuration and care-team management, lab and imaging report templates, protocol versions, and reporting |
+
+### Record access, split by read and write
+
+These are deliberately separate so that read access can be granted without write access.
+
+| Role | Grants |
+| --- | --- |
+| Clinical read | View clinical records — notes, patients, lab and imaging reports, prescriptions, referrals, messages, and related clinical documents |
+| Clinical write | Create and modify clinical records, including notes, plans, prescriptions, referrals, and reasons for visit |
+| Profile read | View patient demographics, contacts, identification cards, and payment methods |
+| Profile write | Modify patient demographics, coverage, consents, contacts, authorizations, and payment details |
+| Document Read | View patient administrative documents |
+| Document Write | Modify patient administrative documents |
+
+### Feature and workflow access
+
+| Role | Grants |
+| --- | --- |
+| Patient Create | Create new patient records |
+| Schedule write | Create and modify appointments |
+| Tasking Access | View and update tasks |
+| Printing Access | Print from the chart |
+| Revenue access | The revenue module and authorization management |
+| Data integration Access | The data integration module |
+| Patient Data Integration Access | Patient-level data integration tasks |
+| Questionnaire Builder Access | The questionnaire builder |
+
+### Security-sensitive roles
+
+Treat these as privileged. They should be assigned narrowly and reviewed on a defined
+cadence.
+
+| Role | Grants |
+| --- | --- |
+| Staff Permissions Access | Manage roles, groups, staff permissions, and patient-group membership — in effect, the ability to grant access to others |
+| Emergency Access | Break-glass access, recorded against a dedicated emergency-access record |
+| Admin Lockout | View and clear failed-login lockouts |
+| Lead | Manage multi-factor authentication devices for users, including TOTP, email, and SMS |
+
+{% include alert.html type="warning" content="Staff Permissions Access is the role that can change other users' access, and Lead can manage their MFA devices. Both warrant the tightest assignment and the most frequent review of any role in the list." %}
+
+Your instance may include additional roles introduced in later releases, or roles created
+by your own administrators.
+
+## Patient groups
+
+Patient groups appear alongside roles in the admin console but behave differently: they
+carry no model permissions of their own. Their purpose is object scoping — assigning a
+user to a patient group determines which patients their permissions apply to.
+
+Every instance is provisioned with an **All Patients** group. Narrower groups are created
+per organization to reflect panels, sites, programs, or any other division that should
+bound a user's reach.
+
+## Extending the defaults
+
+The default roles are a starting point, not a fixed set. Administrators with Staff
+Permissions Access can create additional roles, and adjust the permissions on existing
+ones, to match how the organization actually works. Both are done through the admin
+console.
+
+When you do, a few practices keep the model reviewable:
+
+- Prefer creating a **new role** over broadening an existing one, so the default set stays
+  a recognizable baseline.
+- Grant **read and write separately** where the split exists, rather than defaulting to
+  both.
+- Scope by **patient group** wherever a user does not legitimately need the full
+  population.
+- Review assignments to the security-sensitive roles above on a defined cadence.
+
+## Reviewing access
+
+Because permissions are held by roles rather than individuals, an access review is a
+review of role membership. The admin console lists the staff assigned to each role and the
+patient groups scoping them.
+
+Changes to roles, permissions, and staff records are captured in the audit trail — see
+[Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/) for what is recorded
+and how to export it.
+
+{% include alert.html type="info" content="Canvas can provide a complete role-to-model permission matrix for your instance on request, for use in a security review or access-control audit. Contact your Canvas representative." %}
+
+## Related
+
+- [Platform Security Overview](/guides/platform-security-overview/)
+- [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/)
+- [Plugin Security Model](/guides/plugin-security-model/)


### PR DESCRIPTION
## Why

Customer security reviews keep asking the same questions — how tenants are isolated and which controls a customer inherits versus owns, what plugin code can do at runtime and who approves it before production, what Canvas audits and how to export it, and how access is granted and reviewed. None of it was documented publicly, so every review gets answered from scratch.

Four guides so the next one can be answered with links.

## What

| Page | Covers |
| --- | --- |
| [Platform Security Overview](/guides/platform-security-overview/) | Per-customer instance and database model, the five trust boundaries, platform controls (encryption in transit and at rest, SSO/MFA, model and object permissions, network, privileged access), and the shared-responsibility split |
| [Plugin Security Model](/guides/plugin-security-model/) | Event/effect indirection, runtime isolation, secrets handling, and deployment governance |
| [Audit Logging and Telemetry](/guides/audit-logging-and-telemetry/) | Per-record audit coverage by action type, Provenance change history, authentication and administrative events, retention, and the four export paths |
| [Roles and Permissions](/guides/roles-and-permissions/) | Two-level authorization model, the default roles grouped by purpose, patient-group scoping, extending the defaults, and access review |

Cross-linked to each other and to the existing Provenance, EHI Export, Customer Authentication, Authentication Best Practices, and Plugin Logs pages. Added to `guides_list`. `Plugin Security Model` is registered as a `guide_for: /sdk/` so it also surfaces on the SDK landing page.

## Sourcing

Claims are drawn from the code and from live configuration, not from existing prose.

Plugin isolation and network constraints were read from `canvas-plugins` — the sandbox module allowlist, load-time rejection of disallowed imports, absence of raw socket and non-HTTP protocol libraries, manifest validation. Deployment governance describes the actual gate, which is the OAuth scope on the installing credential.

Role descriptions come from the live `auth_group` / `auth_group_permissions` tables on two Canvas-owned non-production instances, compared by MD5 fingerprint over each role's sorted `model:codename` list. Only roles identical on both are presented as defaults.

The audit table states that chart access is recorded at chart-open and that individual record reads within an open chart are not separately enumerated. A precise scope statement is more useful to a reviewing security team than a vague one, and less likely to read as an overclaim later.

The full per-model permission matrix is deliberately not published — `Roles and Permissions` points readers to their Canvas representative for it, which suits an NDA'd review rather than a public page.

## Verification

- `test-code-blocks.py` byte-identical to the baseline on `main` (1047 blocks, 278 failing before and after); these pages contain no Python blocks
- `_data/menus.yml` parses and the four entries resolve
- Every internal link resolves to an existing file; slugs match the `/:collection/:title/` permalink pattern
- `alert.html` usage matches the existing signature

No local Jekyll build — bundler here is mismatched against the repo's pin and devbox isn't installed, so the Amplify preview is the real rendering check.

## For review

Customer-facing security claims, so worth a closer read than a typical docs change — particularly the shared-responsibility table, deployment governance, and the security-sensitive roles callout, which describe what Canvas provides on request.