### PR TITLE
Correct the authentication section in Platform Security Overview

### DIFF
--- a/collections/_guides/platform-security-overview.md
+++ b/collections/_guides/platform-security-overview.md
@@ -46,11 +46,18 @@ encrypted at rest with AES-256 server-side encryption.
 
 ### Identity and authentication
 
-Canvas supports SSO via SAML, with multi-factor authentication enforced by your identity
-provider. Failed-login lockout is applied to interactive sessions. Where an instance uses
-Canvas-managed credentials rather than SSO, password policy — including minimum length,
-complexity, and screening against known-breached and commonly-used passwords — is
-enforced centrally.
+Canvas supports SSO via SAML. Where an instance uses SSO — the recommended
+configuration — password policy, multi-factor authentication, session lifetime, and
+account lifecycle are governed by your identity provider, and Canvas neither stores nor
+validates those credentials. Deprovisioning a user at your identity provider removes
+their access to Canvas.
+
+Where an instance uses Canvas-managed credentials instead, passwords are validated
+against minimum length, similarity to the user's own name and username, entirely-numeric
+values, and a list of commonly-used passwords.
+
+Failed-login lockout applies to interactive sessions on either path, independent of the
+identity provider.
 
 ### Authorization
 


### PR DESCRIPTION
The Platform Security Overview said that where an instance uses Canvas-managed credentials, password policy "including minimum length, complexity, and screening against known-breached and commonly-used passwords" is enforced centrally.

`home-app` configures four stock Django validators in `app/settings/django.py` and nothing else:

| Validator | Enforces |
| --- | --- |
| `MinimumLengthValidator` | Minimum length |
| `UserAttributeSimilarityValidator` | Not similar to the user's own name or username |
| `CommonPasswordValidator` | Rejects a list of commonly-used passwords |
| `NumericPasswordValidator` | Rejects entirely-numeric passwords |

There is no character-class complexity rule and no breached-credential lookup, so two of the three published claims were wrong. The 16-character minimum, full complexity, breach screening, and password history that the original text was reaching for belong to Canvas's own corporate identity provider, which governs Canvas workforce accounts — not to the product's local credential path.

Rewritten around SSO, which is the recommended configuration and where most instances land: with SAML the customer's identity provider owns password policy, MFA, session lifetime, and account lifecycle, and Canvas neither stores nor validates those credentials. Deprovisioning at the IdP removes Canvas access, which is the more useful statement for a reviewer anyway. The Canvas-managed path now lists the validators that actually run, and failed-login lockout is called out as applying either way.

Verification: `test-code-blocks.py` unchanged against baseline (1047 blocks, 278 failing before and after); no Python blocks on this page. No other page in the security set carried the same claim.