### PR TITLE
docs: document task_list computed property on ImagingOrder and Referral

### DIFF
--- a/collections/_sdk/data/imaging.md
+++ b/collections/_sdk/data/imaging.md
@@ -86,6 +86,15 @@ imaging_order = ImagingOrder.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead1
 tasks = imaging_order.get_task_objects().all()
 ```
 
+The `task_list` computed property returns the same related tasks as a `list[Task]`:
+
+```python
+from canvas_sdk.v1.data.imaging import ImagingOrder
+
+imaging_order = ImagingOrder.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
+tasks = imaging_order.task_list
+```
+
 ## Attributes
 
 ### ImagingOrder

--- a/collections/_sdk/data/referral.md
+++ b/collections/_sdk/data/referral.md
@@ -86,6 +86,15 @@ referral = Referral.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
 tasks = referral.get_task_objects().all()
 ```
 
+The `task_list` computed property returns the same related tasks as a `list[Task]`:
+
+```python
+from canvas_sdk.v1.data.referral import Referral
+
+referral = Referral.objects.get(id="d2194110-5c9a-4842-8733-ef09ea5ead11")
+tasks = referral.task_list
+```
+
 ## Attributes
 
 ### Referral


### PR DESCRIPTION
Follow-up from a full audit of computed properties (`@property` / `@cached_property`) across every model in `canvas_sdk/v1/data/`.

The audit found documentation coverage is otherwise strong — **53 of 55** computed properties are documented, and there are **no stale bullets**. The only in-code-but-undocumented gap was `task_list` (`list[Task]`) on **ImagingOrder** and **Referral**: both pages documented the `get_task_objects()` method but not the `task_list` property. This adds it to each page's "Related Tasks" section.

Not included (need a decision, called out separately):
- **`CustomAttribute`** (`custom_attribute.py`) has a `value` computed property but **no doc page at all** — pending confirmation it's a public SDK model.
- Optional: `patient.md`'s `## Computed Properties` section doesn't list `preferred_pharmacies` / `PatientIdentificationCard.image_url` (documented elsewhere on the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)