### PR TITLE
docs: remove sleep from allowed imports

### DIFF
--- a/collections/_sdk/sandboxing-and-allowed-imports.md
+++ b/collections/_sdk/sandboxing-and-allowed-imports.md
@@ -129,7 +129,6 @@ Provides string constants and template classes for string manipulation and forma
 
 ##### `time`
 Provides time-related functions for measuring execution time and adding delays in processing. [read more](https://docs.python.org/3/library/time.html)
-- `sleep`
 - `time`
 - `time_ns`
 


### PR DESCRIPTION
## Summary

Removes the Python `sleep` function from the documentation. `sleep` was listed as an allowed function under the `time` module in the [Sandboxing and allowed imports](collections/_sdk/sandboxing-and-allowed-imports.md) reference; this drops that entry. `time` and `time_ns` remain listed.

## Note

The Extend AI client examples in `collections/_sdk/clients/extend-ai.md` still call `time.sleep(...)` in polling loops. Left as-is here since they are usage examples rather than documentation of the function; happy to update those too if `sleep` is no longer permitted in the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)