### PR TITLE
chore: build the release notes feed's <summary> as plain text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,11 +59,10 @@ defaults:
     values:
       layout        : "releasenotes"
       # Feed readers (e.g. the Slack RSS app) prefer <summary> over <content>, and
-      # jekyll-feed builds <summary> from the excerpt — which the default separator
-      # ("\n\n") cuts at the intro line, so only "Today's release includes the
-      # following updates:" is previewed. An empty separator stops Jekyll generating
-      # an excerpt at all, so jekyll-feed omits <summary> and readers fall back to
-      # <content>, which carries the full note as HTML (real <ul>/<li> and links).
+      # the default separator ("\n\n") would cut the excerpt at the first
+      # paragraph, previewing a single line of the note. An empty separator stops
+      # Jekyll generating an excerpt at all; release-notes.xml builds <summary>
+      # itself from the whole note instead. See the comment there.
       excerpt_separator: ""
   - scope:
       path          : "collections/_sdk/**/*"

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -176,17 +176,55 @@ collection: release-notes
         Plain text has no tags to cut open and fits far more words. The bullet
         characters injected above survive strip_html (they are text, not
         markup) and so do Kramdown's newlines and indentation, so the digest
-        keeps one line per item and its nesting. 520 characters leaves headroom
-        for the multi-byte bullets, dashes and quotes to stay under the app's
-        byte budget.
+        keeps one line per item and its nesting. 440 characters plus the trailer
+        below leaves headroom for the multi-byte bullets, dashes and quotes to
+        stay under the app's byte budget.
 
         Readers that render <content> are unaffected — they still get the whole
-        note, with its links. The digest is a teaser; the entry title links to
-        the full note.
+        note, with its links.
+
+        Every digest is a teaser, so both paths end with the note's URL. The
+        entry title links there already, but a cut digest gives no sign that the
+        rest exists and an override, which stops wherever its author chose, gives
+        even less. The URL is bare rather than an anchor: Slack linkifies it, and
+        it is the one thing at risk of being cut, so it should degrade to a short
+        URL rather than to a dangling tag. It is written at column 0 below
+        because the newlines and indentation inside the CDATA are the output.
+
+        A note can override the digest with `feed_summary:` in its frontmatter,
+        which is worth doing for a long release where the automatic 440-character
+        cut lands somewhere unhelpful — hand-written, the whole release can be
+        summarised inside the budget. Use a YAML block scalar so the newlines
+        survive, and write plain text: markup is what gets cut open.
+
+            feed_summary: |
+              sdk
+
+              • Questionnaires can now be scored.
+              • Two data models were added: CareTeam and Coverage.
+
+              bugfix
+
+              • The Goals filter classifies by most recent update.
+
+        An override is emitted verbatim — no truncation — because trimming a
+        hand-written digest to 440 characters would defeat the point. Keep it
+        under ~490 characters, which leaves room for the trailer, or Slack does
+        the cutting instead; over that, an XML comment says so in the built feed
+        so it shows up in review. `description:` is honoured too,
+        for jekyll-feed compatibility, but prefer `feed_summary:` — jekyll-seo-tag
+        reads `description` and would put the bullets in the page's meta tag.
       {% endcomment %}
-      {% assign post_summary = post.description | default: post_content | strip_html | strip | truncate: 520, "…" %}
+      {% if post.feed_summary %}
+        {% assign post_summary = post.feed_summary | strip %}
+        {% if post_summary.size > 490 %}<!-- feed_summary is {{ post_summary.size }} characters; with the trailer this exceeds the ~600 bytes the Slack RSS app renders -->{% endif %}
+      {% else %}
+        {% assign post_summary = post.description | default: post_content | strip_html | strip | truncate: 440, "…" %}
+      {% endif %}
       {% if post_summary and post_summary != empty %}
-        <summary type="html"><![CDATA[{{ post_summary }}]]></summary>
+        <summary type="html"><![CDATA[{{ post_summary }}
+
+Full note: {{ post.url | absolute_url }}]]></summary>
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -85,29 +85,51 @@ collection: release-notes
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
+      {% comment %}
+        Changed from upstream: render list items as nested divs carrying their
+        own bullet character, rather than as <ul>/<li>.
+
+        Clients that strip HTML (the Slack RSS app) drop list markup entirely
+        and would show the items as unmarked paragraphs. Simply prefixing <li>
+        with a bullet fixes Slack but doubles the marker in readers that do
+        render lists. Divs carry no marker of their own, so one bullet shows
+        everywhere, and they nest legally at any depth where <p> would not.
+
+        Depth comes from Kramdown's indentation: top-level items are preceded
+        by two spaces, nested ones by six. Do the six-space replace first —
+        "      <li>" contains "  <li>". If that indentation ever changes, a
+        sub-item just falls back to the top-level bullet rather than breaking.
+
+        Also drop the "Today's release includes the following updates:" intro.
+        Every note opens with it, and in a feed the entry title already carries
+        the release date, so it is a line of boilerplate spending a budget the
+        Slack RSS app measures in a few hundred bytes (see <summary> below). It
+        stays on the page itself, where it reads as the note's opening line.
+
+        Kramdown smartifies the apostrophe, so match "’" rather than "'". Some
+        notes put the tag span in the same paragraph as the intro, so replace
+        the sentence rather than the whole <p>, then drop any paragraph that
+        leaves empty. "update:" covers the handful of single-item notes.
+
+        Rouge's class attribute on inline code is 44 bytes of nothing to a feed
+        reader. Dropping it costs no rendering and, should a client render
+        <content> under a byte budget, buys back that much prose per code span.
+
+        Assigned before <summary>, which is built from the same string.
+      {% endcomment %}
+      {% assign post_content = post.content
+           | replace: "      <li>", "      <div>◦ "
+           | replace: "  <li>", "  <div>• "
+           | replace: "</li>", "</div>"
+           | replace: "<ul>", "<div>"
+           | replace: "</ul>", "</div>"
+           | replace: "Today’s release includes the following updates:", ""
+           | replace: "Today’s release includes the following update:", ""
+           | replace: "<p></p>", ""
+           | replace: '<code class="language-plaintext highlighter-rouge">', "<code>" %}
+
       {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only %}
       {% unless excerpt_only %}
-        {% comment %}
-          Changed from upstream: render list items as nested divs carrying their
-          own bullet character, rather than as <ul>/<li>.
-
-          Clients that strip HTML (the Slack RSS app) drop list markup entirely
-          and would show the items as unmarked paragraphs. Simply prefixing <li>
-          with a bullet fixes Slack but doubles the marker in readers that do
-          render lists. Divs carry no marker of their own, so one bullet shows
-          everywhere, and they nest legally at any depth where <p> would not.
-
-          Depth comes from Kramdown's indentation: top-level items are preceded
-          by two spaces, nested ones by six. Do the six-space replace first —
-          "      <li>" contains "  <li>". If that indentation ever changes, a
-          sub-item just falls back to the top-level bullet rather than breaking.
-        {% endcomment %}
-        {% assign post_content = post.content
-             | replace: "      <li>", "      <div>◦ "
-             | replace: "  <li>", "  <div>• "
-             | replace: "</li>", "</div>"
-             | replace: "<ul>", "<div>"
-             | replace: "</ul>", "</div>" %}
         <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}"><![CDATA[{{ post_content | strip }}]]></content>
       {% endunless %}
 
@@ -139,9 +161,32 @@ collection: release-notes
         <category term="{{ tag | xml_escape }}" />
       {% endfor %}
 
-      {% assign post_summary = post.description | default: post.excerpt %}
+      {% comment %}
+        Changed from upstream: build <summary> from the note itself rather than
+        from post.excerpt, which _config.yml switches off.
+
+        The Slack RSS app prefers <summary> over <content> and renders at most
+        ~600 bytes of whatever it is handed, keeping whole whitespace-delimited
+        tokens up to that budget. Handed HTML, the cut lands inside a tag and
+        arrives as a literal "<a..." — 1.338.0 posted that way. Markup also
+        spends the budget: that note delivered 293 of its 395 characters
+        because 62% of the 600 bytes went to tags, Rouge class attributes and
+        hrefs.
+
+        Plain text has no tags to cut open and fits far more words. The bullet
+        characters injected above survive strip_html (they are text, not
+        markup) and so do Kramdown's newlines and indentation, so the digest
+        keeps one line per item and its nesting. 520 characters leaves headroom
+        for the multi-byte bullets, dashes and quotes to stay under the app's
+        byte budget.
+
+        Readers that render <content> are unaffected — they still get the whole
+        note, with its links. The digest is a teaser; the entry title links to
+        the full note.
+      {% endcomment %}
+      {% assign post_summary = post.description | default: post_content | strip_html | strip | truncate: 520, "…" %}
       {% if post_summary and post_summary != empty %}
-        <summary type="html"><![CDATA[{{ post_summary | strip_html | normalize_whitespace }}]]></summary>
+        <summary type="html"><![CDATA[{{ post_summary }}]]></summary>
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -224,7 +224,7 @@ collection: release-notes
       {% if post_summary and post_summary != empty %}
         <summary type="html"><![CDATA[{{ post_summary }}
 
-Full note: {{ post.url | absolute_url }}]]></summary>
+See full notes: {{ post.url | absolute_url }}]]></summary>
       {% endif %}
 
       {% assign post_image = post.image.path | default: post.image %}


### PR DESCRIPTION
Linked Issue
------------

None — reported in Slack: the 1.338.0 entry arrived in the release notes channel with `◦ <a...` where its second bullet should have been.

Description
-----------

The feed was fine. **Slack's RSS app renders at most ~600 bytes of whatever element it picks**, keeping whole whitespace-delimited tokens up to that budget, then escaping the leftovers and appending `...`. Handed HTML, the cut lands inside a tag.

Measured on the only two entries that have ever posted as `<content>`:

| | 1.337.0 (posted whole) | 1.338.0 (cut) |
|---|---|---|
| raw HTML in feed | 596 bytes | 765 bytes |
| prose in the note | 395 chars | 395 chars |
| cut at | — | 492 bytes (293 chars delivered) |
| next token would have ended at | — | **606 bytes** |

Same prose in both; the difference is markup. 62% of 1.338.0's budget went to tags, Rouge class attributes and hrefs.

The app **prefers `<summary>` over `<content>`** — which is why every note before 2026-08-10 previewed only its intro line, and why removing `<summary>` in 05b874b90 switched Slack to the full-content path. So this builds `<summary>` deliberately rather than leaving Slack to chew on HTML:

- `<summary>` is now `post_content | strip_html | strip | truncate: 520, "…"`. Plain text has nothing to cut open, fits far more words, and degrades to a word-boundary `…` if the real limit is below 600. The injected `•`/`◦` markers and Kramdown's newlines survive `strip_html`, so the digest keeps one line per item and its nesting.
- `<content>` is unchanged in substance — readers that render it still get the whole note with working links. Long notes now show ~2–3 bullets then `…` in Slack, with the entry title linking to the full note.
- Dropped from the feed only: the `Today's release includes the following updates:` intro (every note repeats it and the entry's own date makes it redundant — **it stays in the markdown, so the pages are unchanged**) and Rouge's 44-byte `class` attribute on inline code.
- `_config.yml`'s comment on `excerpt_separator: ""` described the old rationale; corrected.

## Verification

Local `bundle exec jekyll build`:

- XML parses; 20 entries, every summary markup-free and intro-free, largest 542 bytes against the ~600 budget (the 2.7–4.2 KB notes now end in a clean `…` instead of mid-tag).
- 1.338.0's `<content>` 765 → 617 bytes, links intact.

What Slack should post for 1.338.0:

```
08.12.2026          <- clickable, links to the note
sdk

  • The following were added to the SDK data module:
      ◦ PatientAdministrativeDocument exposes the administrative documents on a
        patient's chart, along with their document coding and a document_url for
        the file itself.
      ◦ UncategorizedClinicalDocument gains a code property, so plugins can read
        the document's coding.
```

Entry `<id>`s are untouched, so no re-post to subscribers; the app may re-render the already-posted messages in place.

The ~600-byte figure is bracketed by those two observations rather than confirmed against a documented limit — the 520-char cap sits well inside it, and plain text fails gracefully if it's lower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ons in 754ef06a

**Per-note override.** A long release still gets cut at an arbitrary point, so a note can set `feed_summary:` in its frontmatter and summarise the whole release by hand inside the budget:

```yaml
feed_summary: |
  sdk

  • Plugins can now read and write patient consents, and the data module gained
    CareTeam and Coverage.

  bugfix

  • The Goals "Active/Closed" filter now classifies by most recent update.
```

Emitted verbatim — trimming a hand-written digest would defeat the point — so an over-long one earns an XML comment in the built feed where review will see it (`<!-- feed_summary is 663 characters; ... -->`). The key is deliberately not `description:`, which `jekyll-seo-tag` reads: a digest full of bullet characters does not belong in the page's `<meta name="description">`. Verified the page meta tag is untouched.

**Always a way through to the details.** Both paths now end with `Full note: <url>`. The entry title links there already, but a truncated digest gives no sign the rest exists, and an override — which stops wherever its author chose — gives even less. Bare URL rather than an anchor, deliberately: Slack linkifies it, and as the last thing in the string it is the one part at risk of being cut, so it should degrade to a short URL rather than a dangling tag. The automatic cut drops 520 → 440 characters to pay for it.

Rebuilt: XML parses, all 20 entries end with their note URL, largest summary 526 bytes against the ~600 budget.
