### PR TITLE
docs: document sandbox runtime restrictions and correct type() claim

### DIFF
--- a/collections/_sdk/canvas_cli.md
+++ b/collections/_sdk/canvas_cli.md
@@ -238,7 +238,7 @@ This command runs full pre-flight validation combining:
 
 #### Static lint
 
-Before it loads any handlers, `canvas validate` scans every `.py` file in the plugin — skipping directories like `tests`, `build`, and `dist` — for patterns that compile cleanly but fail, or silently misbehave, once your code runs on the instance. Each finding is reported with a rule code in brackets. Warnings are printed but do not block validation; any error fails the command and exits with code 1.
+Before it loads any handlers, `canvas validate` scans every `.py` file in the plugin — skipping directories like `tests`, `build`, and `dist` *within* the plugin — for patterns that compile cleanly but fail, or silently misbehave, once your code runs on the instance. Each finding is reported with a rule code in brackets. Warnings are printed but do not block validation; any error fails the command and exits with code 1.
 
 ```console
 $ canvas validate my_plugin
@@ -255,8 +255,9 @@ These issues will fail on the instance (sandbox / Custom Data):
 | `setattr-blocked` | `setattr(obj, "x", value)` — use `obj.x = value` |
 | `delattr-blocked` | `delattr(obj, "x")` — use `del obj.x` |
 | `bytearray-blocked` | `bytearray(...)` — use `bytes` for binary data |
-| `type-3arg-blocked` | `type(name, bases, dict)` dynamic class creation — declare the class with `class …:` |
+| `type-blocked` | Any call to `type()`. It is absent from the sandbox builtins, so even the one-argument `type(x)` raises `NameError` — use `isinstance(x, SomeClass)` or `x.__class__.__name__`, and declare classes with `class …:` rather than `type(name, bases, dict)` |
 | `augmented-subscript` | Augmented assignment on a subscript, e.g. `d[k] += v` — rewrite as `d[k] = d[k] + v` |
+| `augmented-attribute` | Augmented assignment on an attribute, e.g. `obj.attr += v` — rewrite as `obj.attr = obj.attr + v` |
 
 `@dataclass(frozen=True)` and `@dataclass(slots=True)` load and run fine in the sandbox and are intentionally not flagged.
 

--- a/collections/_sdk/sandboxing-and-allowed-imports.md
+++ b/collections/_sdk/sandboxing-and-allowed-imports.md
@@ -345,7 +345,37 @@ The following Python builtin functions are available within the sandbox:
 - `super`
 - `vars`
 
-Plus all the standard safe builtins from RestrictedPython including basic types (`bool`, `int`, `float`, `str`, `tuple`, etc.) and safe operations.
+On top of those, the sandbox inherits RestrictedPython's safe builtins. That covers the basic types (`bool`, `bytes`, `complex`, `float`, `frozenset`, `int`, `set`, `slice`, `str`, `tuple`), the common functions (`abs`, `callable`, `chr`, `divmod`, `hash`, `hex`, `id`, `isinstance`, `issubclass`, `len`, `oct`, `ord`, `pow`, `range`, `repr`, `round`, `sorted`, `zip`), and most of the standard exception classes.
+
+### Builtins that are not available
+
+What you see above is the whole set. The sandbox works from an allow-list rather than a list of banned names, so any builtin not mentioned there raises `NameError` when your plugin runs — including builtins that future Python releases introduce.
+
+These are the ones plugin authors reach for most often:
+
+| Not available | Use instead |
+| --- | --- |
+| `eval`, `exec`, `compile` | Write the logic directly. The sandbox cannot run code it never reviewed. |
+| `open`, `input` | Neither the filesystem nor a console is reachable from a plugin. |
+| `print` | `log` from `logger`. `print` is also a [reserved name](#reserved-names). |
+| `type` | `isinstance(x, SomeClass)` to test a type, `x.__class__.__name__` to read its name. |
+| `dir`, `globals`, `locals` | Nothing. Namespace introspection is a sandbox-escape route. |
+| `bytearray` | `bytes` for binary data. |
+
+One group is easy to miss: the `OSError` subclasses, including `TimeoutError`, `ConnectionError`, `FileNotFoundError`, and `PermissionError`. Writing `except TimeoutError:` around an HTTP call raises `NameError`. Catch `OSError` instead — it is available, and it matches every one of them:
+
+```python?partial=true
+from canvas_sdk.utils import Http
+
+client = Http()
+
+try:
+    response = client.get("https://example.com/api")
+except OSError:
+    # OSError is the shared base class, so this catches TimeoutError,
+    # ConnectionError, and the rest of the family.
+    pass
+```
 
 ## Forbidden Constructs
 
@@ -357,9 +387,12 @@ Beyond the import allow-list above, a few Python constructs compile under Restri
 | `delattr(obj, "x")` | Dynamic attribute deletion is blocked | `del obj.x` |
 | `bytearray(...)` | Not available in the sandbox | `bytes` for binary data |
 | `type(name, bases, dict)` | Dynamic class creation (3-argument `type`) is not available | Declare the class normally with `class …:` |
-| `d[k] += v` | Augmented assignment on a dict item, list item, or slice is rejected | Explicit reassignment: `d[k] = d[k] + v` |
+| `obj.attr += v` | Augmented assignment to an attribute is rejected, including on classes you defined yourself | Explicit reassignment: `obj.attr = obj.attr + v` |
+| `d[k] += v` | Augmented assignment to a dict item, list item, or slice is rejected | Explicit reassignment: `d[k] = d[k] + v` |
 
-One-argument `type(x)` (checking an object's type) is allowed — only the three-argument form used for dynamic class creation is rejected.
+Augmented assignment to a plain variable is fine — `count += 1`, `total *= 2`, and the rest of the `-=` / `*=` / `//=` / `%=` / `**=` / `&=` / `|=` / `^=` / `<<=` / `>>=` family all work. It is only the attribute and item forms above that are rejected, and both fail when the plugin is compiled, so you find out at install time rather than mid-request. Note that `canvas validate` currently reports only the item form, not the attribute form.
+
+{% include alert.html type="warning" content="<code>type</code> is not available in the sandbox <em>at all</em>, including the one-argument <code>type(x)</code> form used to check an object's type — it raises <code>NameError: name 'type' is not defined</code>. <code>canvas validate</code> only reports the three-argument form, so a one-argument call passes validation and then fails at runtime. Use <code>isinstance(x, SomeClass)</code> to test a type, or <code>x.__class__.__name__</code> to read its name." %}
 
 {% include alert.html type="info" content="<code>@dataclass(frozen=True)</code> and <code>@dataclass(slots=True)</code> load and run fine in the sandbox — they are not forbidden." %}
 
@@ -384,6 +417,120 @@ except Exception:
     for frame in frames:
         log.info(f"{frame.filename}:{frame.lineno} in {frame.name}")
 ```
+
+## Runtime Restrictions
+
+The sandbox enforces the rules in this section every time an attribute is read or written, so they surface as an `AttributeError` while your plugin is running. That is what separates them from the [forbidden constructs](#forbidden-constructs), which are rejected when your code is compiled and reported by `canvas validate` before you install. Nothing described here is caught until the code executes.
+
+Throughout this section, **your plugin's code** means modules inside your own plugin package. **External code** means everything else — the Canvas SDK, the standard library, and third-party modules.
+
+### Reading attributes
+
+Attribute names that begin with an underscore are restricted, and the rule depends on where the object came from:
+
+| Object defined in | `_single_underscore` | `__dunder__` |
+| --- | --- | --- |
+| Your plugin's code | Readable | Only names on the allow-list below |
+| External code | Blocked | Only names on the allow-list below |
+
+The dunder allow-list is the same in both cases:
+
+- `__annotations__`
+- `__args__`
+- `__class__`
+- `__dict__`
+- `__eq__`
+- `__init__`
+- `__members__`
+- `__name__`
+- `__origin__`
+- `__traceback__`
+
+Two of those return a restricted stand-in rather than the real object:
+
+- **`__class__`** on an object defined outside your plugin returns a read-only proxy that exposes only `__name__`. This is what prevents `__class__.__mro__` and `__class__.__subclasses__()` from being used to reach code outside the sandbox.
+- **`__traceback__`** returns a safe traceback exposing only `tb_frame`, `tb_lineno`, and `tb_next`. Its frame exposes only `f_code`, and that code object exposes only `co_filename` and `co_name`. Local and global variables are never reachable. [`extract_exc_frames()`](#extract_exc_frames) is the more convenient way to read a traceback.
+
+Reading a plain attribute off an imported module is also limited to that module's entry in the allow-list at the top of this page. `json.dumps` works because `dumps` is listed under `json`; `json.tool` raises an `AttributeError`.
+
+### Reading items
+
+Subscripting with a string key that starts with an underscore is blocked on every object, including dictionaries you created yourself:
+
+```python?partial=true
+config = {"timeout": 30, "_internal": True}
+
+config["timeout"]    # fine
+config["_internal"]  # AttributeError
+```
+
+### Writing attributes
+
+You can set attributes on modules that belong to your plugin. Setting an attribute on any other module is blocked.
+
+For objects, whether a write is allowed depends on where the object's class was defined:
+
+- **Class defined in your plugin's code** — writable, including attributes that are not methods.
+- **Class defined in external code** — the write is blocked if any of the following is true:
+  - the name you are assigning through was brought in by an `import`
+  - the attribute currently holds a callable, so the assignment would replace a method
+  - the target is a dictionary and the key is a string starting with an underscore
+
+```python?partial=true
+class MyThing:
+    """Defined in your plugin, so its instances are writable."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+
+thing = MyThing()
+thing.count = 1       # fine
+thing.label = "new"   # fine
+```
+
+### Reserved names
+
+These four names cannot be used for a function, variable, class, or argument anywhere in your plugin:
+
+- `print`
+- `printed`
+- `builtins`
+- `breakpoint`
+
+`print` is among them, so use the SDK logger for output:
+
+```python?partial=true
+from logger import log
+
+log.info("plugin started")
+```
+
+### Introspection attributes
+
+The attributes the `inspect` module relies on are unavailable, because they expose frames, globals, and raw bytecode:
+
+`co_code`, `cr_await`, `cr_code`, `cr_frame`, `cr_origin`, `f_back`, `f_builtins`, `f_code`, `f_generator`, `f_globals`, `f_locals`, `f_trace`, `gi_code`, `gi_frame`, `gi_yieldfrom`, `tb_frame`, `tb_next`
+
+The safe traceback wrappers under [reading attributes](#reading-attributes) are the one exception: they re-expose `tb_frame`, `tb_next`, and `f_code` through an explicit allow-list, stripped down to the fields listed there.
+
+### String formatting
+
+The `format` and `format_map` methods of `str` are not available. Use an f-string or the `%` operator instead:
+
+```python?partial=true
+name = "Canvas"
+
+greeting = f"Hello {name}"       # fine
+greeting = "Hello %s" % name     # fine
+greeting = "Hello {}".format(name)  # NotImplementedError
+```
+
+### `__exports__`
+
+Some SDK objects declare an `__exports__` attribute listing exactly which attribute names may be read from them. Where it is present it takes precedence over the other rules in this section: names in the list are readable, and anything else raises an `AttributeError`.
+
+{% include alert.html type="info" content="These rules are enforced by <code>plugin_runner/sandbox.py</code> in the <a href='https://github.com/canvas-medical/canvas-plugins'>Canvas Plugins repository</a>, which is the authoritative reference if you hit a restriction that isn't described here." %}
 
 ## Requesting Additional Imports
 

--- a/collections/_sdk/sandboxing-and-allowed-imports.md
+++ b/collections/_sdk/sandboxing-and-allowed-imports.md
@@ -390,9 +390,9 @@ Beyond the import allow-list above, a few Python constructs compile under Restri
 | `obj.attr += v` | Augmented assignment to an attribute is rejected, including on classes you defined yourself | Explicit reassignment: `obj.attr = obj.attr + v` |
 | `d[k] += v` | Augmented assignment to a dict item, list item, or slice is rejected | Explicit reassignment: `d[k] = d[k] + v` |
 
-Augmented assignment to a plain variable is fine — `count += 1`, `total *= 2`, and the rest of the `-=` / `*=` / `//=` / `%=` / `**=` / `&=` / `|=` / `^=` / `<<=` / `>>=` family all work. It is only the attribute and item forms above that are rejected, and both fail when the plugin is compiled, so you find out at install time rather than mid-request. Note that `canvas validate` currently reports only the item form, not the attribute form.
+Augmented assignment to a plain variable is fine — `count += 1`, `total *= 2`, and the rest of the `-=` / `*=` / `//=` / `%=` / `**=` / `&=` / `|=` / `^=` / `<<=` / `>>=` family all work. It is only the attribute and item forms above that are rejected, and both fail when the plugin is compiled, so you find out at install time rather than mid-request.
 
-{% include alert.html type="warning" content="<code>type</code> is not available in the sandbox <em>at all</em>, including the one-argument <code>type(x)</code> form used to check an object's type — it raises <code>NameError: name 'type' is not defined</code>. <code>canvas validate</code> only reports the three-argument form, so a one-argument call passes validation and then fails at runtime. Use <code>isinstance(x, SomeClass)</code> to test a type, or <code>x.__class__.__name__</code> to read its name." %}
+{% include alert.html type="warning" content="<code>type</code> is not available in the sandbox <em>at all</em>, including the one-argument <code>type(x)</code> form used to check an object's type — it raises <code>NameError: name 'type' is not defined</code>. Use <code>isinstance(x, SomeClass)</code> to test a type, or <code>x.__class__.__name__</code> to read its name." %}
 
 {% include alert.html type="info" content="<code>@dataclass(frozen=True)</code> and <code>@dataclass(slots=True)</code> load and run fine in the sandbox — they are not forbidden." %}
 

--- a/collections/_sdk/sandboxing-and-allowed-imports.md
+++ b/collections/_sdk/sandboxing-and-allowed-imports.md
@@ -364,7 +364,7 @@ These are the ones plugin authors reach for most often:
 
 One group is easy to miss: the `OSError` subclasses, including `TimeoutError`, `ConnectionError`, `FileNotFoundError`, and `PermissionError`. Writing `except TimeoutError:` around an HTTP call raises `NameError`. Catch `OSError` instead — it is available, and it matches every one of them:
 
-```python?partial=true
+```python
 from canvas_sdk.utils import Http
 
 client = Http()
@@ -457,7 +457,7 @@ Reading a plain attribute off an imported module is also limited to that module'
 
 Subscripting with a string key that starts with an underscore is blocked on every object, including dictionaries you created yourself:
 
-```python?partial=true
+```python
 config = {"timeout": 30, "_internal": True}
 
 config["timeout"]    # fine
@@ -476,7 +476,7 @@ For objects, whether a write is allowed depends on where the object's class was 
   - the attribute currently holds a callable, so the assignment would replace a method
   - the target is a dictionary and the key is a string starting with an underscore
 
-```python?partial=true
+```python
 class MyThing:
     """Defined in your plugin, so its instances are writable."""
 
@@ -500,7 +500,7 @@ These four names cannot be used for a function, variable, class, or argument any
 
 `print` is among them, so use the SDK logger for output:
 
-```python?partial=true
+```python
 from logger import log
 
 log.info("plugin started")
@@ -518,7 +518,7 @@ The safe traceback wrappers under [reading attributes](#reading-attributes) are 
 
 The `format` and `format_map` methods of `str` are not available. Use an f-string or the `%` operator instead:
 
-```python?partial=true
+```python
 name = "Canvas"
 
 greeting = f"Hello {name}"       # fine


### PR DESCRIPTION
Closes [KOALA-2873](https://canvasmedical.atlassian.net/browse/KOALA-2873).

That ticket asks for the Notion page [Scratch: Python sandbox limitations](https://www.notion.so/canvasmedical/Scratch-Python-sandbox-limitations-1df0bd9e4033806c96f9d3925c8b0ad2) to make it onto the docs site, and [Mary asked on the ticket](https://canvasmedical.atlassian.net/browse/KOALA-2873) whether it belonged on the existing sandboxing page. It does — that page is already in the SDK nav and already owns this topic, so this extends it rather than adding a second page.

## Corrects a wrong claim on the live page

The page currently says:

> One-argument `type(x)` (checking an object's type) is allowed — only the three-argument form used for dynamic class creation is rejected.

This is false. `type` is not in the sandbox builtins at all. canvas-plugins asserts this in `test_type_is_inaccessible`, where a **one-argument** `type(client)` raises `NameError: name 'type' is not defined`. Because `plugin_lint.py` only matches the three-argument form, a one-argument call passes `canvas validate` and then fails on the instance — the worst combination. Replaced with a warning pointing at `isinstance()` and `x.__class__.__name__`.

## Adds

**A Runtime Restrictions section** — the attribute and assignment rules the sandbox enforces at runtime, which the page never covered:

- underscore and dunder attribute reads, and how they differ for plugin-owned vs external objects
- the `__class__` and `__traceback__` safe proxies, and why they exist (blocking `__mro__` / `__subclasses__` escapes)
- underscore item access
- write rules, split by where the object's class was defined
- the four reserved names (`print`, `printed`, `builtins`, `breakpoint`)
- the `inspect` attribute blocklist and its safe-wrapper exception
- `str.format` / `str.format_map`, which were undocumented anywhere on the site
- `__exports__`

**Which builtins are absent** — framed as "the allow-list is the contract" rather than an enumerated blocklist, since that set is derived from `dir(builtins)` minus the allow-list and would drift with every Python release. Calls out that the `OSError` subclasses (`TimeoutError`, `ConnectionError`, ...) are unavailable and `OSError` has to be caught instead.

**`obj.attr += v`** to the forbidden constructs table. Augmented assignment to an attribute is rejected even on classes you defined yourself, it was missing from the docs, and `canvas validate` does not report it (`plugin_lint.py:111` only matches a `Subscript` target).

## Sourcing

Written from `plugin_runner/sandbox.py` and `canvas_cli/apps/plugin/plugin_lint.py` at canvas-plugins v0.197.0, not from the Notion page. The Notion page is a "Scratch" doc from 2025-04-24 and three of its nine bullets have since gone stale:

| Notion claim | Actual behaviour |
| --- | --- |
| Module attribute assignment blocked regardless of plugin membership | Only external modules; plugin-owned modules are writable |
| Dunder read allow-list differs between plugin and non-plugin code | The two lists are byte-identical; the real split is single-underscore names |
| No writes to any attribute of anything created outside plugin code | Blocked only for imported names, callables, and underscore dict keys |

Every claim in the new content was exercised against a sandbox built with the repo's own `_sandbox_from_code` test helper rather than inferred from reading the source.

## Verification

- `uv run ./test-code-blocks.py` — all 1122 blocks pass, including the 6 new ones
- `bundle exec jekyll build` — exits 0; both tables and the alert includes render
- all cross-links checked against generated anchor IDs in the built HTML

## Follow-up, not in this PR

The import tables are hand-maintained — the page's history is a dozen one-off "add X to allowed imports" commits. canvas-plugins already auto-generates `plugin_runner/allowed-module-imports.json` via pre-commit, so those tables could be generated from it. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-2873]: https://canvasmedical.atlassian.net/browse/KOALA-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ