### PR TITLE
docs: document the change medication patient-ownership validation

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -547,7 +547,7 @@ assess = AssessCommand(
 
 | Name            | Type     | Required to commit | Description                                                        |
 |:----------------|:---------|:---------|:-------------------------------------------------------------------|
-| `medication_id` | _string_ | `true`   | The id of the [Medication](/sdk/data-medication/#medication) being changed. Must be a medication on that patient's chart. |
+| `medication_id` | _string_ | `true`   | The id of the [Medication](/sdk/data-medication/#medication) being changed. Must be an active medication on that patient's chart. |
 | `sig`           | _string_ | `false`  | Administration details of the medication.                          |
 
 **Example**:
@@ -561,6 +561,14 @@ change_medication = ChangeMedicationCommand(
     sig='two pills taken orally'
 )
 ```
+
+**Validation**:
+
+`medication_id` must belong to the same patient as the note or command it is written to: the patient comes from `note_uuid` when you `originate` the command, and from the existing command when you `edit` one. A medication on another patient's chart — or an id that matches no active medication at all — fails validation, and the command is neither created nor updated. Previously such an id was accepted and the command was created with no medication on it.
+
+The id also has to be well formed. A value that cannot be an id fails validation rather than reaching the lookup.
+
+This check is deferred when the target note (on `originate`) or command (on `edit`) is not yet persisted — for example, when a plugin creates the note and originates `ChangeMedicationCommand`s against that same `note_uuid` in a single handler response. In that case the note's or command's patient cannot be resolved yet, so `medication_id` passes this validation.
 
 ---
 


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6684

The ChangeMedication parameter table already said `medication_id` "must be a medication on that
patient's chart", but nothing said what happened when it was not - and until now nothing enforced it.
The command was created with no medication on it and no error anywhere.

Adds a **Validation** paragraph in the same shape as the one on [Assess](/sdk/commands/#assess), which
documents the same check:

- where the patient comes from on `originate` versus `edit`
- that a medication on another patient's chart, or an id matching no active medication, fails validation
  and the command is neither created nor updated - with a note that this used to be accepted
- that a malformed id fails validation rather than reaching the lookup
- that the check is deferred when the note or command is not persisted yet, so a plugin creating a note
  and originating commands against it in one response still works

Also qualifies the table description as an **active** medication, which is what the check requires.

Corresponding SDK change: canvas-plugins#1823.