### PR TITLE
docs: note the allergy narrative character limit

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -452,7 +452,7 @@ AdjustPrescriptionCommand(
 |:-------------------|:----------------|:---------|:---------------------------------------------------------------------------------|
 | `allergy`          | _[Allergen](#allergy-allergen)_      | `false`  | Represents the allergen. See details in the [Allergen](#allergy-allergen) type below. Search allergens with the [ontologies allergen search](/sdk/utils/#get-fdballergy--full-text-search).                 |
 | `severity`         | _[Severity](#allergy-severity) enum_ | `false`  | The severity of the allergic reaction. Must be one of [`AllergyCommand.Severity`](#allergy-severity). |
-| `narrative`        | _string_        | `false`  | A narrative or free-text description of the allergy.                             |
+| `narrative`        | _string_        | `false`  | A narrative or free-text description of the allergy (max length: 512 characters). |
 | `approximate_date` | _datetime_      | `false`  | The approximate date the allergy was identified.                                 |
 
 **Enums and Types**:


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6682

`AllergyCommand.narrative` is now capped at 512 characters, and the parameter table said nothing about
a limit at all.

Phrased as `(max length: 512 characters)`, following the other command parameters that carry a cap -
Diagnose's `today_assessment`, Medical History's `comments`, Past Surgical History's `comment`.

Corresponding SDK change: canvas-plugins#1826.