### PR TITLE
docs: note the remove allergy narrative character limit

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -2042,7 +2042,7 @@ RefillCommand(
 | Name         | Type     | Required to commit | Description                                      |
 |--------------|----------|----------|--------------------------------------------------|
 | `allergy_id` | _string_ | `true`   | The id of the [AllergyIntolerance](/sdk/data-allergy-intolerance/#allergyintolerance) to remove. Must be an allergy already recorded on that patient's chart.        |
-| `narrative`  | _string_ | `false`  | Additional context or narrative for the removal. |
+| `narrative`  | _string_ | `false`  | Additional context or narrative for the removal (max length: 512 characters). |
 
 **Example**:
 


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6712

`RemoveAllergyCommand.narrative` is now capped at 512 characters, and the parameter table said nothing about a limit.

Phrased as `(max length: 512 characters)`, following the other capped command parameters.

The ownership rule the same change enforces is already documented on the `allergy_id` row, so that is left as is.

Corresponding SDK change: canvas-plugins#1833.