### PR TITLE
docs: note the medication statement sig character limit

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -1163,7 +1163,7 @@ MedicalHistoryCommand(
 | Name       | Type                 | Required to commit | Description                                            |
 |:-----------|:---------------------|:---------|:-------------------------------------------------------|
 | `fdb_code` | _string_ or _[Coding](#coding)_ | `true`   | The [FDB code](/sdk/utils/#fdb_code) of the medication |
-| `sig`      | _string_             | `false`  | Administration details of the medication.              |
+| `sig`      | _string_             | `false`  | Administration details of the medication (max length: 1000 characters). |
 
 **Coding Support**:
 


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6699

`MedicationStatementCommand.sig` is now capped at 1000 characters, and the parameter row said nothing about a limit.

Phrased as `(max length: 1000 characters)`, following the other capped command parameters.

Corresponding SDK change: canvas-plugins#1830.