### PR TITLE
docs: correct the update goal goal_id to the goal's id, not its dbid

### DIFF
--- a/collections/_sdk/commands.md
+++ b/collections/_sdk/commands.md
@@ -2331,7 +2331,7 @@ UpdateDiagnosisCommand(
 
 | Name                 | Type                     | Required to commit | Description                                               |
 |:---------------------|:-------------------------|:---------|:----------------------------------------------------------|
-| `goal_id`            | _string_                 | `true`   | The `dbid` of the [Goal](/sdk/data-goal/#goal) being updated. Must be a goal on that patient's chart.        |
+| `goal_id`            | _string_                 | `true`   | The `id` of the [Goal](/sdk/data-goal/#goal) being updated. Must be a goal on that patient's chart.        |
 | `due_date`           | _datetime_               | `false`  | The date the goal is due.                                 |
 | `achievement_status` | _[AchievementStatus](#updategoal-achievementstatus) enum_ | `false`  | The current achievement status of the goal.               |
 | `priority`           | _[Priority](#updategoal-priority) enum_          | `false`  | The priority of the goal.                                 |


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6720

The Update Goal parameter row described `goal_id` as the goal's `dbid`, which does not match the field: it is typed `string` and is matched against the goal's `id`. Passing a `dbid` here does not resolve.

Close Goal is the one that takes a `dbid`, and is typed `int` accordingly - the two rows read as if they take the same value, and they do not.

This surfaced while adding the patient-ownership check for this command, which matches on `id`.

The ownership rule itself is already documented on the same row, so it is left as is.

Corresponding SDK change: canvas-plugins#1835.